### PR TITLE
Add source platform and channel name to archive entries

### DIFF
--- a/src/conversation-archive.ts
+++ b/src/conversation-archive.ts
@@ -31,6 +31,8 @@ export interface ArchiveEntry {
   chatId: number;
   role: "user" | "assistant";
   content: string;
+  source?: "telegram" | "discord";
+  channelName?: string;
 }
 
 /** YYYY-MM-DD for a timestamp (or now). */
@@ -56,10 +58,12 @@ export function archiveMessage(
   role: "user" | "assistant",
   content: string,
   ts: number,
+  meta?: { source?: "telegram" | "discord"; channelName?: string },
 ): void {
   try {
     fs.mkdirSync(ARCHIVE_DIR, { recursive: true });
-    const line = JSON.stringify({ ts, chatId, role, content } satisfies ArchiveEntry);
+    const entry: ArchiveEntry = { ts, chatId, role, content, ...meta };
+    const line = JSON.stringify(entry);
     fs.appendFileSync(localArchivePath(datestamp(ts)), line + "\n");
   } catch (err: any) {
     // Never let archiving crash the bot

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -75,7 +75,8 @@ function saveToDisk(store: Map<number, Message[]>): Promise<void> {
 export async function addMessage(
   chatId: number,
   role: "user" | "assistant",
-  content: string
+  content: string,
+  meta?: { source?: "telegram" | "discord"; channelName?: string },
 ): Promise<void> {
   const store = await ensureLoaded();
 
@@ -87,7 +88,7 @@ export async function addMessage(
   history.push({ role, content, timestamp: now });
 
   // Archive every message before the rolling window clips it
-  archiveMessage(chatId, role, content, now);
+  archiveMessage(chatId, role, content, now, meta);
 
   // Trim to max length
   if (history.length > MAX_HISTORY) {

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -161,7 +161,12 @@ client.on("messageCreate", async (message: Message) => {
     // Use last 9 digits of channelId as numeric chatId for conversation tracking
     const chatId = parseInt(message.channelId.slice(-9), 10);
 
-    void addMessage(chatId, "user", userMessage);
+    const channelName = message.channel.type === ChannelType.DM
+      ? "dm"
+      : (message.channel as TextChannel).name ?? "unknown";
+    const meta = { source: "discord" as const, channelName };
+
+    void addMessage(chatId, "user", userMessage, meta);
 
     const rawResponse = await chat(chatId, userMessage);
 
@@ -171,7 +176,7 @@ client.on("messageCreate", async (message: Message) => {
       .replace(new RegExp("<think>[\\s\\S]*?" + thinkClose, "g"), "")
       .trim();
 
-    void addMessage(chatId, "assistant", response);
+    void addMessage(chatId, "assistant", response, meta);
 
     // Discord max message length is 2000 chars
     const formatted = toDiscordMarkdown(response);

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -102,7 +102,8 @@ async function handleAiResponse(
 
   try {
     // Fire-and-forget — don't block message processing on disk writes
-    void addMessage(chatId, "user", userMessage);
+    const meta = { source: "telegram" as const };
+    void addMessage(chatId, "user", userMessage, meta);
 
     const rawResponse = await chatWithRetry(chatId, userMessage, onChunk, image);
 
@@ -110,7 +111,7 @@ async function handleAiResponse(
     const thinkClose = "<" + "/think>";
     const response = rawResponse.replace(new RegExp("<think>[\\s\\S]*?" + thinkClose, "g"), "").trim();
 
-    void addMessage(chatId, "assistant", response);
+    void addMessage(chatId, "assistant", response, meta);
 
     // Final render — replace the streaming message with the complete response.
     // Split on the original text (before MarkdownV2 conversion) so escape


### PR DESCRIPTION
## Summary
- Archive JSONL entries now include optional `source` ("telegram" | "discord") and `channelName` fields
- `addMessage()` in `conversation.ts` accepts and passes through optional metadata to the archiver
- Telegram messages are tagged with `source: "telegram"`; Discord messages include both `source: "discord"` and the channel name (or "dm" for direct messages)
- Fully backwards compatible — all new fields are optional, existing JSONL archives parse without changes

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (no archive test changes needed — new fields are optional)
- [ ] Send a message via Telegram, verify the JSONL line in `~/.chris-assistant/archive/` includes `"source":"telegram"`
- [ ] Send a message via Discord in a named channel, verify the JSONL line includes `"source":"discord","channelName":"<channel-name>"`
- [ ] Send a DM via Discord, verify the JSONL line includes `"channelName":"dm"`
- [ ] Verify old archive files (without source/channelName) still load correctly via `readLocalArchive()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)