### PR TITLE
Reduce archive backup interval to 30min and flush on shutdown

### DIFF
--- a/src/conversation-archive.ts
+++ b/src/conversation-archive.ts
@@ -20,7 +20,7 @@ import { writeMemoryFile } from "./memory/github.js";
 // ---------------------------------------------------------------------------
 
 const ARCHIVE_DIR = path.join(os.homedir(), ".chris-assistant", "archive");
-const UPLOAD_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const UPLOAD_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 
 // ---------------------------------------------------------------------------
 // Local archiving (called from addMessage — must be fast & never throw)
@@ -111,7 +111,7 @@ function hashContent(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
-async function uploadArchives(): Promise<void> {
+export async function uploadArchives(): Promise<void> {
   let files: string[];
   try {
     files = fs.readdirSync(ARCHIVE_DIR).filter((f) => f.endsWith(".jsonl"));
@@ -143,7 +143,7 @@ export function startArchiveUploader(): void {
     return;
   }
 
-  console.log("[archive] Starting archive uploader (every 6 hours)");
+  console.log("[archive] Starting archive uploader (every 30 minutes)");
 
   // Immediate upload on startup
   uploadArchives().catch((err: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { startDiscord, stopDiscord } from "./discord.js";
 import { startHealthMonitor, stopHealthMonitor } from "./health.js";
 import { startScheduler, stopScheduler } from "./scheduler.js";
 import { startConversationBackup, stopConversationBackup } from "./conversation-backup.js";
-import { startArchiveUploader, stopArchiveUploader } from "./conversation-archive.js";
+import { startArchiveUploader, stopArchiveUploader, uploadArchives } from "./conversation-archive.js";
 import { startDailySummarizer, stopDailySummarizer } from "./conversation-summary.js";
 import { startJournalUploader, stopJournalUploader } from "./memory/journal.js";
 import { startMemoryConsolidation, stopMemoryConsolidation } from "./memory-consolidation.js";
@@ -48,11 +48,12 @@ bot.start({
 });
 
 // Graceful shutdown
-const shutdown = () => {
+const shutdown = async () => {
   console.log("[chris-assistant] Shutting down...");
   stopHealthMonitor();
   stopScheduler();
   stopConversationBackup();
+  await uploadArchives();
   stopArchiveUploader();
   stopDailySummarizer();
   stopJournalUploader();


### PR DESCRIPTION
## Summary
- Reduces `UPLOAD_INTERVAL_MS` from 6 hours to 30 minutes, shrinking the worst-case message loss window from 6h to 30min
- Exports `uploadArchives()` so it can be called from the shutdown path
- Calls `await uploadArchives()` in the graceful shutdown handler (before stopping the uploader timer) to flush any pending archive changes on restart

## Test plan
- [ ] Verify bot starts and log shows "Starting archive uploader (every 30 minutes)"
- [ ] Confirm archive uploads happen on a ~30 minute cadence (check GitHub commits in the memory repo)
- [ ] Run `chris restart` and verify the shutdown log shows archive upload activity before "Archive uploader stopped"
- [ ] Verify `npm run typecheck` passes
- [ ] Verify `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)