### PR TITLE
Add /purge command for full conversation clear

### DIFF
--- a/src/conversation-archive.ts
+++ b/src/conversation-archive.ts
@@ -115,6 +115,47 @@ function hashContent(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
+/**
+ * Remove all archive entries for a given chatId from a date's JSONL file.
+ * Rewrites the file in place, excluding entries matching the chatId.
+ * Returns the number of entries removed.
+ */
+export function redactArchiveEntries(chatId: number, date: string): number {
+  const filePath = localArchivePath(date);
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const lines = raw.split("\n").filter(Boolean);
+    const kept: string[] = [];
+    let removed = 0;
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as ArchiveEntry;
+        if (entry.chatId === chatId) {
+          removed++;
+        } else {
+          kept.push(line);
+        }
+      } catch {
+        kept.push(line); // preserve unparseable lines
+      }
+    }
+
+    if (removed > 0) {
+      if (kept.length > 0) {
+        fs.writeFileSync(filePath, kept.join("\n") + "\n");
+      } else {
+        fs.writeFileSync(filePath, ""); // empty file so uploadArchives() overwrites GitHub copy
+      }
+    }
+
+    return removed;
+  } catch {
+    return 0; // file doesn't exist or can't be read
+  }
+}
+
+
 export async function uploadArchives(): Promise<void> {
   let files: string[];
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ console.log("[chris-assistant] Starting up...");
 bot.api.setMyCommands([
   { command: "start", description: "Greeting" },
   { command: "clear", description: "Reset conversation + Claude session" },
+  { command: "purge", description: "Full clear — conversation + today's archive" },
   { command: "stop", description: "Abort current Claude query" },
   { command: "session", description: "Show Claude session info" },
   { command: "model", description: "Show current AI model" },

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -12,6 +12,7 @@ import { getWorkspaceRoot, setWorkspaceRoot, isProjectActive } from "./tools/fil
 import { invalidatePromptCache } from "./providers/shared.js";
 import { clearSession, getSessionId } from "./claude-sessions.js";
 import { abortClaudeQuery } from "./providers/claude.js";
+import { datestamp, redactArchiveEntries, uploadArchives } from "./conversation-archive.js";
 
 const bot = new Bot(config.telegram.botToken);
 
@@ -156,6 +157,32 @@ bot.command("clear", async (ctx) => {
   await ctx.reply("Conversation cleared. Memory is still intact.");
 });
 
+// /purge — full clear including archives
+bot.command("purge", async (ctx) => {
+  const chatId = ctx.chat.id;
+
+  // Clear rolling window + Claude session
+  await clearHistory(chatId);
+  clearSession(chatId);
+
+  // Redact today's archive
+  const today = datestamp();
+  const removed = redactArchiveEntries(chatId, today);
+
+  // Push redacted archive to GitHub immediately
+  if (removed > 0) {
+    uploadArchives().catch((err: any) => {
+      console.error("[telegram] Failed to upload redacted archive:", err.message);
+    });
+  }
+
+  await ctx.reply(
+    removed > 0
+      ? `Conversation purged. ${removed} archive entries removed from today's log.`
+      : "Conversation cleared. No archive entries found for today.",
+  );
+});
+
 // /model — show current model and provider
 bot.command("model", async (ctx) => {
   const model = config.model;
@@ -236,6 +263,7 @@ bot.command("help", async (ctx) => {
     "Available commands:\n\n" +
     "/start — Greeting\n" +
     "/clear — Reset conversation + Claude session\n" +
+    "/purge — Full clear — conversation + today's archive\n" +
     "/stop — Abort current Claude query\n" +
     "/session — Show Claude session info\n" +
     "/model — Show current AI model\n" +


### PR DESCRIPTION
## Summary
- New `/purge` Telegram command that clears the conversation window, resets the Claude session, and redacts today's archive entries for the current chat
- Adds `redactArchiveEntries()` function to `conversation-archive.ts` that rewrites JSONL files in place, excluding entries matching a chatId
- Exports `uploadArchives()` so the redacted archive can be pushed to GitHub immediately after purge
- Adds `/purge` to the Telegram command menu and `/help` output

## Test plan
- [ ] Send several messages, then run `/purge` — verify reply shows count of removed entries
- [ ] Check `~/.chris-assistant/archive/YYYY-MM-DD.jsonl` — entries for the chat should be gone
- [ ] Verify the redacted archive is uploaded to GitHub (check `archive/` in memory repo)
- [ ] Run `/purge` again immediately — should report "No archive entries found for today"
- [ ] Verify `/clear` still works independently (no regression)
- [ ] Run `npm run typecheck` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)