### PR TITLE
Convert schedule editor modal to right-side drawer

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -956,9 +956,12 @@ function cronToType(expr) {
 }
 
 // --- Schedule modal ---
+var drawerCloseTimer = null;
 function openScheduleModal(id) {
   const s = schedulesData.find(function(x) { return x.id === id; });
   if (!s) return;
+
+  if (drawerCloseTimer) { clearTimeout(drawerCloseTimer); drawerCloseTimer = null; }
 
   document.getElementById("sched-id").value = s.id;
   document.getElementById("modal-title").textContent = "Edit: " + s.name;
@@ -992,7 +995,7 @@ function openScheduleModal(id) {
 function closeScheduleModal() {
   var overlay = document.getElementById("schedule-modal");
   overlay.classList.remove("open");
-  setTimeout(function() { overlay.style.display = "none"; }, 300);
+  drawerCloseTimer = setTimeout(function() { overlay.style.display = "none"; drawerCloseTimer = null; }, 300);
 }
 
 document.getElementById("sched-enabled").addEventListener("change", function() {


### PR DESCRIPTION
## Summary
- Replaces the centered modal with a full-height drawer sliding in from the right
- Form content and logic stay identical — only the container presentation changes
- Slide-in/out animation via CSS transform + transition

## Changes
- **CSS**: `.modal-overlay` simplified to plain backdrop, `.modal-card` now fixed right-edge drawer (480px, 100vh), `.modal-overlay.open .modal-card` triggers slide-in
- **JS**: `openScheduleModal()` uses `display: block` + double-rAF to add `.open` class
- **JS**: `closeScheduleModal()` removes `.open` class, waits 300ms for transition, then hides
- `max-width: 90vw` ensures mobile responsiveness

## Test plan
- [ ] Click a schedule row — drawer slides in from right
- [ ] Click backdrop — drawer slides out
- [ ] Save a schedule — drawer closes with animation, toast appears
- [ ] Delete a schedule — same close animation
- [ ] Scroll within drawer if form is taller than viewport
- [ ] Test on narrow viewport — drawer respects 90vw max

🤖 Generated with [Claude Code](https://claude.com/claude-code)