### PR TITLE
Add Calendar tab CSS and HTML scaffold

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -563,6 +563,36 @@ tr.clickable:hover { background: var(--bg3); }
 .badge-error { background: rgba(248, 113, 113, 0.15); color: var(--red); }
 .badge-neutral { background: var(--bg3); color: var(--text2); }
 .badge-accent { background: rgba(108, 138, 255, 0.15); color: var(--accent); }
+.cal-color-0 { background: rgba(96, 165, 250, 0.15); border-left: 3px solid #60a5fa; color: #60a5fa; }
+.cal-color-1 { background: rgba(74, 222, 128, 0.15); border-left: 3px solid #4ade80; color: #4ade80; }
+.cal-color-2 { background: rgba(251, 191, 36, 0.15); border-left: 3px solid #fbbf24; color: #fbbf24; }
+.cal-color-3 { background: rgba(192, 132, 252, 0.15); border-left: 3px solid #c084fc; color: #c084fc; }
+.cal-color-4 { background: rgba(251, 146, 60, 0.15); border-left: 3px solid #fb923c; color: #fb923c; }
+.cal-color-5 { background: rgba(34, 211, 238, 0.15); border-left: 3px solid #22d3ee; color: #22d3ee; }
+.cal-color-6 { background: rgba(248, 113, 113, 0.15); border-left: 3px solid #f87171; color: #f87171; }
+.cal-color-7 { background: rgba(196, 181, 253, 0.15); border-left: 3px solid #c4b5fd; color: #c4b5fd; }
+.cal-toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+.cal-toolbar .cal-nav { display: flex; gap: 4px; }
+.cal-toolbar .cal-title { font-size: 16px; font-weight: 600; color: var(--text); min-width: 200px; }
+.cal-week { display: grid; grid-template-columns: 60px repeat(7, 1fr); gap: 1px; background: var(--border); border-radius: 8px; overflow: hidden; }
+.cal-week-header { background: var(--bg2); padding: 8px 6px; text-align: center; font-size: 12px; font-weight: 600; color: var(--text2); }
+.cal-week-header.today { color: var(--accent); }
+.cal-time-label { background: var(--bg2); padding: 4px 6px; font-size: 11px; color: var(--text2); text-align: right; display: flex; align-items: flex-start; justify-content: flex-end; }
+.cal-week-cell { background: var(--bg1); padding: 4px; min-height: 48px; display: flex; flex-direction: column; gap: 2px; }
+.cal-event { padding: 2px 6px; border-radius: 4px; font-size: 11px; cursor: default; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cal-event.disabled { opacity: 0.45; }
+.cal-month { display: grid; grid-template-columns: repeat(7, 1fr); gap: 1px; background: var(--border); border-radius: 8px; overflow: hidden; }
+.cal-month-header { background: var(--bg2); padding: 8px 6px; text-align: center; font-size: 12px; font-weight: 600; color: var(--text2); }
+.cal-month-cell { background: var(--bg1); padding: 6px; min-height: 80px; }
+.cal-month-cell .day-num { font-size: 12px; color: var(--text2); margin-bottom: 4px; }
+.cal-month-cell.today { border: 1px solid var(--accent); }
+.cal-month-cell.outside { opacity: 0.35; }
+.cal-month-event { padding: 1px 4px; border-radius: 3px; font-size: 10px; margin-bottom: 2px; cursor: default; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cal-dot-row { display: flex; gap: 3px; flex-wrap: wrap; margin-top: 2px; }
+.cal-dot { width: 8px; height: 8px; border-radius: 50%; }
+.cal-legend { display: flex; flex-wrap: wrap; gap: 12px; padding: 8px 0; }
+.cal-legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text2); }
+.cal-legend-swatch { width: 12px; height: 12px; border-radius: 3px; }
 .flex-between { display: flex; justify-content: space-between; align-items: center; }
 </style>
 </head>
@@ -580,6 +610,7 @@ tr.clickable:hover { background: var(--bg3); }
     <button class="tab" data-tab="conversations">Conversations</button>
     <button class="tab" data-tab="memory">Memory</button>
     <button class="tab" data-tab="logs">Logs</button>
+    <button class="tab" data-tab="calendar">Calendar</button>
   </div>
 
   <!-- Status -->
@@ -699,6 +730,29 @@ tr.clickable:hover { background: var(--bg3); }
       <div class="segmented" id="log-mode"><button class="active" data-mode="live">Live</button><button data-mode="snapshot">Snapshot</button></div>
     </div>
     <div class="log-container" id="log-output"><span class="loading">Connecting...</span></div>
+  </div>
+
+  <!-- Calendar -->
+  <div class="section" id="sec-calendar">
+    <div class="card">
+      <div class="cal-toolbar">
+        <div class="cal-nav">
+          <button class="btn btn-cancel" id="cal-prev">\u25C0</button>
+          <button class="btn btn-cancel" id="cal-today">Today</button>
+          <button class="btn btn-cancel" id="cal-next">\u25B6</button>
+        </div>
+        <span class="cal-title" id="cal-title"></span>
+        <div class="segmented" id="cal-view-toggle">
+          <button class="active" data-view="week">Week</button>
+          <button data-view="month">Month</button>
+        </div>
+      </div>
+      <div id="cal-grid"><div><div class="skeleton skeleton-row"></div><div class="skeleton skeleton-row medium"></div><div class="skeleton skeleton-row"></div><div class="skeleton skeleton-row short"></div></div></div>
+    </div>
+    <div class="card">
+      <h3>Legend</h3>
+      <div class="cal-legend" id="cal-legend-items"></div>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Add 8 calendar color classes (`.cal-color-0` through `.cal-color-7`) for schedule event styling
- Add CSS for week grid, month grid, event pills, dots, legend, and toolbar
- Add Calendar tab button and section HTML with skeleton loader placeholder
- No JS logic yet — tab is clickable but shows skeleton state

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (156 tests)
- [ ] Dashboard loads, Calendar tab appears and is clickable
- [ ] Other tabs still function normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)