### PR TITLE
Add Knowledge Base link to dashboard header

### DIFF
--- a/docs/cli/environment.md
+++ b/docs/cli/environment.md
@@ -24,6 +24,7 @@ description: Environment variables, file paths, and configuration
 | `DISCORD_GUILD_ID` | No | Discord guild ID for channel management |
 | `DASHBOARD_PORT` | No | Web dashboard port. Default: `3000` |
 | `DASHBOARD_TOKEN` | No | API key for dashboard auth. If unset, dashboard is localhost-only |
+| `DOCS_URL` | No | URL for "Knowledge Base" link in dashboard header. If unset, no link shown |
 | `GITHUB_WEBHOOK_SECRET` | No | HMAC secret for GitHub webhook signature verification |
 | `WEBHOOK_PORT` | No | Webhook server port. Default: `3001` |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,7 @@ export const config = {
   dashboard: {
     port: Number(process.env.DASHBOARD_PORT || "3000"),
     token: process.env.DASHBOARD_TOKEN || null,
+    docsUrl: process.env.DOCS_URL || null,
   },
   webhook: {
     secret: process.env.GITHUB_WEBHOOK_SECRET || null,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -425,6 +425,8 @@ body { font-family: var(--font); background: var(--bg); color: var(--text); min-
 header { display: flex; align-items: center; gap: 12px; padding: 16px 0; border-bottom: 1px solid var(--border); margin-bottom: 16px; }
 header h1 { font-size: 20px; font-weight: 600; }
 header .badge { font-size: 12px; background: var(--bg3); color: var(--text2); padding: 2px 8px; border-radius: 10px; }
+header .docs-link { margin-left: auto; font-size: 13px; color: var(--text2); text-decoration: none; display: flex; align-items: center; gap: 4px; transition: color 0.15s; }
+header .docs-link:hover { color: var(--accent); }
 
 /* Tabs */
 .tabs { display: flex; gap: 4px; margin-bottom: 16px; flex-wrap: wrap; }
@@ -602,7 +604,8 @@ tr.clickable:hover { background: var(--bg3); }
   <header>
     <h1>Chris Assistant</h1>
     <span class="badge" id="provider-badge">loading...</span>
-  </header>
+` + (config.dashboard.docsUrl ? `    <a class="docs-link" href="${config.dashboard.docsUrl}" target="_blank" rel="noopener noreferrer">\u{1F4DA} Knowledge Base</a>
+` : '') + `  </header>
 
   <div class="tabs">
     <button class="tab active" data-tab="status">Status</button>


### PR DESCRIPTION
## Summary
- Adds a configurable "Knowledge Base" link to the dashboard header
- Controlled by `DOCS_URL` env var — link only renders when set
- Opens in new tab with `rel="noopener noreferrer"`
- Styled subtly on the right side of the header, highlights on hover

## Configuration
```bash
chris config set DOCS_URL https://docs.yourdomain.com
```

## Test plan
- [ ] Without `DOCS_URL` set: no link visible in header
- [ ] With `DOCS_URL` set: link appears, opens correct URL in new tab
- [ ] Hover state transitions to accent color

🤖 Generated with [Claude Code](https://claude.com/claude-code)