### PR TITLE
fix: isolate scheduler from interactive sessions and handle pre-formed HTML

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -102,3 +102,23 @@ export function toMarkdownV2(text: string): string {
 
   return processed;
 }
+
+/**
+ * Detect whether text looks like it already contains Telegram HTML tags.
+ * Used to avoid double-processing responses that are already HTML-formatted.
+ */
+function looksLikeHtml(text: string): boolean {
+  return /<(b|i|u|s|code|pre|a\s)[\s>]/i.test(text);
+}
+
+/**
+ * Convert AI response text to Telegram HTML, regardless of whether the AI
+ * emitted Markdown or pre-formed HTML. Safe to call on any AI output.
+ */
+export function prepareForTelegram(text: string): string {
+  if (looksLikeHtml(text)) {
+    // Already HTML — just escape any stray & that aren't already entity refs
+    return text.replace(/&(?!(?:amp|lt|gt|quot|apos);)/g, "&amp;");
+  }
+  return toMarkdownV2(text);
+}

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -12,7 +12,7 @@ import * as path from "path";
 import { config } from "./config.js";
 import { chat } from "./providers/index.js";
 import { sendToDiscordChannel } from "./discord.js";
-import { toMarkdownV2 } from "./markdown.js";
+import { prepareForTelegram } from "./markdown.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -165,8 +165,9 @@ async function executeTask(task: Schedule): Promise<void> {
   console.log("[scheduler] Executing task: %s (%s) — %s", task.name, task.id, toolInfo);
 
   try {
-    // Use the user's actual chat ID so the AI has conversation context
-    const chatId = config.telegram.allowedUserId;
+    // Use chatId 0 for scheduled tasks — isolates them from interactive sessions
+    // (prevents session resume from contaminating AI output format)
+    const chatId = 0;
     const response = await chat(chatId, task.prompt, undefined, undefined, task.allowedTools);
 
     // Skip sending if response is empty, whitespace, or starts with NOUPDATE:
@@ -176,7 +177,7 @@ async function executeTask(task: Schedule): Promise<void> {
     } else if (task.discordChannel) {
       await sendToDiscordChannel(task.discordChannel, trimmed);
     } else {
-      await sendTelegramMessage(toMarkdownV2(trimmed), task.name);
+      await sendTelegramMessage(prepareForTelegram(trimmed), task.name);
     }
 
     // Update lastRun


### PR DESCRIPTION
## Summary

Fixes the scheduled task formatting bug (#35) with two targeted changes:

- **`chatId = 0` in `executeTask()`** — scheduled tasks no longer resume the user's interactive Claude session. Previously using the user's actual chatId meant the AI would pick up HTML formatting patterns from prior conversations and output `<b>` tags. When `toMarkdownV2()` then ran on that output, it escaped `<b>` → `&lt;b&gt;`, causing tags to render literally in Telegram.

- **`prepareForTelegram()` in `markdown.ts`** — new helper that detects whether AI output already contains Telegram HTML tags (e.g. `<b>`, `<code>`, `<a >`). If so, passes through with minimal escaping. Otherwise falls back to `toMarkdownV2()` for Markdown input. Used by the scheduler in place of `toMarkdownV2()` directly.

## Test plan

- [ ] Trigger Morning Report manually — bold headers should render correctly
- [ ] Trigger Market Snapshot — emoji + bold formatting renders correctly
- [ ] Interactive Telegram messages unaffected (no changes to `telegram.ts`)
- [ ] Discord-routed tasks unaffected (only the `sendTelegramMessage` path changed)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)