### PR TITLE
fix: raise macos_mail loop guard limit for batch operations

### DIFF
--- a/src/tools/claude-mcp-adapter.ts
+++ b/src/tools/claude-mcp-adapter.ts
@@ -20,7 +20,7 @@ const NATIVE_CLAUDE_TOOLS = new Set([
 function toMcpTool(tool: ReturnType<typeof getRegisteredTools>[number]) {
   return createMcpTool(tool.name, tool.description, tool.zodSchema, async (args: any) => {
     const argsJson = JSON.stringify(args);
-    const loopError = checkToolLoop(tool.name, argsJson);
+    const loopError = checkToolLoop(tool.name, argsJson, tool.frequencyLimit);
     if (loopError) {
       return {
         content: [{ type: "text" as const, text: loopError }],

--- a/src/tools/loop-guard.ts
+++ b/src/tools/loop-guard.ts
@@ -1,14 +1,19 @@
 const LOOP_THRESHOLD = 3;
-const FREQUENCY_LIMIT = 20;
+const DEFAULT_FREQUENCY_LIMIT = 20;
 
 let recentFingerprints: string[] = [];
 const toolCallCounts = new Map<string, number>();
 
-export function checkToolLoop(name: string, argsJson: string): string | null {
+/**
+ * Check for tool call loops and frequency abuse.
+ * @param frequencyLimit - per-tool override; falls back to DEFAULT_FREQUENCY_LIMIT (20)
+ */
+export function checkToolLoop(name: string, argsJson: string, frequencyLimit?: number): string | null {
+  const limit = frequencyLimit ?? DEFAULT_FREQUENCY_LIMIT;
   const count = (toolCallCounts.get(name) ?? 0) + 1;
   toolCallCounts.set(name, count);
 
-  if (count >= FREQUENCY_LIMIT) {
+  if (count >= limit) {
     console.warn("[tools] Frequency limit reached: %s called %d times this conversation", name, count);
     return `Tool ${name} has been called ${count} times this conversation. You appear to be stuck — try a different approach or ask the user for help.`;
   }

--- a/src/tools/macos.ts
+++ b/src/tools/macos.ts
@@ -636,6 +636,7 @@ registerTool({
 registerTool({
   name: "macos_mail",
   category: "always",
+  frequencyLimit: 100,
   description:
     `Interact with macOS Mail app (default account: ${DEFAULT_MAIL_ACCOUNT}). ` +
     "Actions: summary, inbox, search, read, reply, delete, move, mark, list_mailboxes. " +

--- a/src/tools/openai-adapter.ts
+++ b/src/tools/openai-adapter.ts
@@ -19,7 +19,7 @@ export async function dispatchToolCall(name: string, argsJson: string, logPrefix
   if (!tool) return `Unknown tool: ${name}`;
 
   try {
-    const loopError = checkToolLoop(name, argsJson);
+    const loopError = checkToolLoop(name, argsJson, tool.frequencyLimit);
     if (loopError) return loopError;
 
     const args = JSON.parse(argsJson);

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -13,4 +13,6 @@ export interface ToolRegistration {
     properties: Record<string, any>;
   };
   execute: (args: any) => Promise<string>;
+  /** Per-tool frequency limit for loop guard. Defaults to 20 if not set. */
+  frequencyLimit?: number;
 }


### PR DESCRIPTION
## Summary
- Adds per-tool `frequencyLimit` override to tool registration (default remains 20)
- Sets `macos_mail` to 100 calls per conversation to support inbox triage workflows
- Identical-args loop detection (3 consecutive identical calls) unchanged

## Problem
Organising an inbox requires ~3-4 tool calls per email (list, read, move/mark). At 20 calls, the assistant gets cut off after ~6 emails — not enough for real inbox triage.

## Test plan
- [ ] Verify `npm run typecheck` passes
- [ ] Confirm other tools still hit the default 20-call limit
- [ ] Test mail-heavy conversation exceeds 20 calls without being blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)