### PR TITLE
docs: fix README gaps and update tool documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Critical ones inline, full list in `docs/development/gotchas.md`:
 
 ## Environment
 
-See `src/config.ts` for all env vars. Key ones: `TELEGRAM_BOT_TOKEN`, `GITHUB_TOKEN`, `GITHUB_MEMORY_REPO`, `AI_MODEL`. Auth tokens stored in `~/.chris-assistant/`.
+Config is validated through `src/infra/config/` (`src/config.ts` is a facade). Key ones: `TELEGRAM_BOT_TOKEN`, `GITHUB_TOKEN`, `GITHUB_MEMORY_REPO`, `AI_MODEL`. Auth tokens stored in `~/.chris-assistant/`.
 
 ## Adding Things
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ Built for a single user. Not a platform, not a framework — just a really good 
 | **Code** | Runs JavaScript, TypeScript, Python, and shell commands. Reads, writes, and edits files. Full git integration. |
 | **Calendar & Mail** | Native macOS Calendar (EventKit) and Mail integration. "Move my dentist appointment to Friday at 3pm" just works. |
 | **SSH** | Connects to Tailscale devices, runs commands in persistent tmux sessions you can attach to from your phone. |
+| **Reminders** | Native Apple Reminders integration (EventKit). Create, complete, update, and search tasks. |
 | **Scheduling** | "Check Hacker News every morning" — creates cron tasks that run with full AI + tool access. |
 | **Skills** | Reusable workflows the AI can discover, execute, and create at runtime. Stored as JSON in the memory repo. |
+| **Usage Tracking** | Token usage and cost tracking per model/provider. On-demand reports and daily cost summaries. |
+| **Health Monitoring** | Heartbeat checks, service health status, and GitHub webhook server for PR monitoring. |
 
 ## How It Works
 
@@ -256,11 +259,17 @@ Maintenance:
 | `AI_MODEL` | No | Model ID — determines provider (default: `gpt-4o`) |
 | `BRAVE_SEARCH_API_KEY` | No | Enables web search tool |
 | `WORKSPACE_ROOT` | No | Root for file/git tools (default: `~/Projects`) |
+| `CLAUDE_MODEL` | No | Alternative to `AI_MODEL` — used if `AI_MODEL` is not set |
+| `IMAGE_MODEL` | No | Model for image generation (default: `gpt-5.2`) |
+| `MAX_TOOL_TURNS` | No | Max tool call turns per conversation (default: 200) |
 | `DISCORD_BOT_TOKEN` | No | Enables Discord bot |
 | `DISCORD_ALLOWED_USER_ID` | No | Your Discord user ID |
+| `DISCORD_GUILD_ID` | No | Discord server ID |
 | `DASHBOARD_TOKEN` | No | Auth token for remote dashboard access |
+| `WEBHOOK_PORT` | No | GitHub webhook server port (default: 3001) |
+| `SYMPHONY_STATUS_URL` | No | Symphony status page URL (default: `http://127.0.0.1:3010`) |
 
-Full list in `src/config.ts`. Run `chris setup` for guided configuration.
+Config is validated through a typed zod schema in `src/infra/config/` (`src/config.ts` is a compatibility facade). Run `chris setup` for guided configuration.
 
 ## Architecture
 
@@ -280,6 +289,7 @@ src/
 ├── tools/                   # Tool registry platform + tool modules
 ├── dashboard/               # Dashboard runtime + UI template
 ├── skills/                  # Dynamic workflow system
+├── swift/                   # Swift source for EventKit binaries (Calendar, Reminders)
 ├── cli/                     # Commander.js CLI
 └── symphony/                # Autonomous workflow/orchestration subsystem
 ```

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
           { text: 'Code Execution', link: '/tools/code-execution' },
           { text: 'Memory', link: '/tools/memory' },
           { text: 'Scheduler', link: '/tools/scheduler' },
+          { text: 'macOS (Calendar, Mail, Reminders)', link: '/tools/macos' },
         ],
       },
       {

--- a/docs/token-usage-tracking.md
+++ b/docs/token-usage-tracking.md
@@ -1,144 +1,58 @@
 # Token Usage Tracking
 
-## Goal
+## Overview
 
-Capture real token usage from every AI API call and store daily snapshots. The primary use case is model price comparison — understanding what each provider actually costs per day based on real usage patterns.
+Token usage from every AI API call is captured and stored as daily JSONL snapshots. The primary use case is model price comparison — understanding what each provider actually costs per day based on real usage patterns.
 
----
+## How It Works
 
-## Current state
+Each provider records token usage as a side-effect after every API call. Usage data is appended to daily JSONL files:
 
-No token tracking exists. API responses are consumed for text and tool calls only — the `usage` field returned by every provider is silently discarded. The only token-related code is a rough character-based estimator used for context compaction decisions (`src/providers/compaction.ts`).
+```
+~/.chris-assistant/usage/YYYY-MM-DD.jsonl
+```
 
----
+Each line contains: timestamp, provider, model, input tokens, output tokens, and calculated cost.
 
-## What each provider returns
+## What Each Provider Returns
 
-All three providers return token counts in their API responses:
+All providers return token counts in their API responses:
 
-**OpenAI (Codex Responses API)**
-Available on the final streaming event:
+**OpenAI (Responses API)**
 ```json
 { "usage": { "input_tokens": 1240, "output_tokens": 183 } }
 ```
 
 **Claude (Agent SDK)**
-Available on the `result` message event:
 ```json
 { "usage": { "input_tokens": 980, "output_tokens": 241 } }
 ```
 
 **MiniMax (OpenAI-compatible)**
-Available on the final streaming chunk:
 ```json
 { "usage": { "prompt_tokens": 860, "completion_tokens": 97, "total_tokens": 957 } }
 ```
 
----
+## On-Demand Reports
 
-## Proposed implementation
+The `get_usage_report` tool provides usage reports via conversation:
 
-### 1. Capture tokens in each provider
+- **Single day**: "How much did I spend today?" — shows per-model breakdown with call counts and costs
+- **Multi-day**: "Show me the last 7 days of usage" — daily totals with rolling average
 
-Each provider's `chat()` method should extract usage from the final API response and return it alongside the text response. The `Provider` interface would gain an optional `usage` field on the return type:
+Parameters:
+- `date` — date in `YYYY-MM-DD` format (defaults to today)
+- `days` — number of days to include (defaults to 1)
 
-```typescript
-// src/providers/types.ts
-export interface TokenUsage {
-  inputTokens: number;
-  outputTokens: number;
-  model: string;
-  provider: "claude" | "openai" | "minimax";
-}
+## Pricing
 
-export interface ChatResult {
-  text: string;
-  usage?: TokenUsage;
-}
-```
+Token pricing is stored in a config file (`~/.chris-assistant/token-pricing.json`) so it can be updated without code changes.
 
-Or more conservatively, keep the existing `chat()` signature unchanged and add a separate side-effect call to a usage recorder after each response.
+## Files
 
-### 2. Usage recorder
-
-A lightweight module that appends to a daily JSONL file:
-
-```typescript
-// src/usage-tracker.ts
-export function recordUsage(usage: TokenUsage): void
-
-// Writes to: ~/.chris-assistant/usage/YYYY-MM-DD.jsonl
-// Each line: { ts, provider, model, inputTokens, outputTokens }
-```
-
-### 3. Daily snapshot & cost calculation
-
-A nightly schedule (or on-demand tool) that:
-- Reads today's JSONL file
-- Groups by provider + model
-- Applies known per-token pricing
-- Produces a cost summary
-
-**Reference pricing (as of early 2026, per 1M tokens):**
-
-| Model | Input | Output |
-|---|---|---|
-| claude-sonnet-4-6 | $3.00 | $15.00 |
-| gpt-4o | $2.50 | $10.00 |
-| gpt-5.2 (image model) | $5.00 | $20.00 |
-| MiniMax | varies | varies |
-
-Pricing should be stored in a config file (not hardcoded) so it can be updated without a code change.
-
-### 4. Daily report format
-
-Posted to Telegram (or a Discord channel) at midnight:
-
-```
-📊 Token Usage — 07 Mar 2026
-
-🤖 claude-sonnet-4-6
-   ↳ 142 calls  |  1.2M input  |  180k output
-   💰 $3.60 + $2.70 = $6.30
-
-🧠 gpt-5.2 (vision)
-   ↳ 3 calls  |  12k input  |  1.8k output
-   💰 $0.06 + $0.04 = $0.10
-
-Total today: $6.40
-7-day avg:   $5.80/day
-```
-
----
-
-## Files to create / modify
-
-| File | Change |
-|---|---|
-| `src/providers/types.ts` | Add `TokenUsage` interface |
-| `src/usage-tracker.ts` | New — append usage to daily JSONL |
-| `src/providers/claude.ts` | Extract usage from result event |
-| `src/providers/openai.ts` | Extract usage from final stream event |
-| `src/providers/minimax.ts` | Extract usage from final stream chunk |
-| `src/providers/index.ts` | Pass usage through to tracker after each call |
-| `src/tools/usage.ts` | New — `get_usage_report` tool for on-demand queries |
+| File | Purpose |
+|------|---------|
+| `src/usage-tracker.ts` | Core tracker — append usage, read daily summaries, format reports |
+| `src/tools/usage.ts` | `get_usage_report` tool registration |
 | `~/.chris-assistant/usage/` | Runtime data directory for daily JSONL files |
 | `~/.chris-assistant/token-pricing.json` | Editable pricing config per model |
-
----
-
-## Implementation approach options
-
-**Option A — Modify Provider interface (cleaner, more testable)**
-Change `chat()` to return `ChatResult` with both text and usage. Callers extract text as before, usage gets passed to the tracker. Requires updating all call sites.
-
-**Option B — Side-effect recording (zero call-site changes)**
-Each provider calls `recordUsage()` internally before returning. No interface changes needed. Simpler to ship incrementally.
-
-Option B is lower risk and can be done one provider at a time.
-
----
-
-## Priority
-
-Medium. No existing tracking means there's no historical data — the sooner this is added, the sooner meaningful comparisons are possible. Even a week of real data would be enough to make an informed model decision.

--- a/docs/tools/macos.md
+++ b/docs/tools/macos.md
@@ -5,7 +5,7 @@ description: Calendar (EventKit) and Mail (AppleScript) integration for macOS
 
 # macOS Tools
 
-Two macOS-only tools: `macos_calendar` (fast native EventKit) and `macos_mail` (AppleScript). Both are platform-gated — they only register on `darwin`.
+Three macOS-only tools: `macos_calendar` (fast native EventKit), `macos_mail` (AppleScript), and `macos_reminders` (fast native EventKit). All are platform-gated — they only register on `darwin`.
 
 ## Calendar (`macos_calendar`)
 
@@ -120,12 +120,49 @@ Uses AppleScript via `osascript` to interact with Mail.app. Default account: **i
 | Action | Required Params | Optional Params | Description |
 |--------|----------------|-----------------|-------------|
 | `summary` | — | — | Total and unread message counts |
-| `inbox` | — | `count`, `unread_only` | Recent messages (default 5, max 20) |
-| `search` | `query` | `count` | Search by subject or sender (default 10, max 20) |
+| `inbox` | — | `count`, `unread_only`, `mailbox` | Recent messages (default 5, max 20) |
+| `search` | `query` | `count`, `mailbox` | Search by subject or sender (default 10, max 20) |
+| `read` | `message_id` | — | Get full message content (subject, from, to, cc, date, body) |
+| `reply` | `message_id`, `body` | `reply_all` | Reply to a message (confirm content with user first) |
+| `delete` | `message_id` | — | Move message to Trash |
+| `move` | `message_id`, `mailbox` | — | Move message to a specific mailbox |
+| `mark` | `message_id`, `mark_as` | — | Mark as `read`, `unread`, `flagged`, or `unflagged` |
+| `list_mailboxes` | — | — | Show available mailbox names |
+
+Message IDs are returned in inbox/search results as `id:...` fields. Use these for `read`, `reply`, `delete`, `move`, and `mark` actions.
 
 ### Implementation
 
 AppleScript is written to temp files and executed via `/usr/bin/osascript` (multi-line scripts don't work reliably with `-e` flag). 120s timeout to handle Mail.app's slow scripting bridge. Output truncated at 50KB.
+
+## Reminders (`macos_reminders`)
+
+Uses a compiled Swift EventKit binary (`~/.chris-assistant/ChrisReminders.app`) for fast reminder operations. Default list: **Reminders**. Same `.app` bundle architecture as Calendar for TCC permissions.
+
+### Actions
+
+| Action | Required Params | Optional Params | Description |
+|--------|----------------|-----------------|-------------|
+| `list_lists` | — | — | List all reminder list names |
+| `get_reminders` | — | `list`, `include_completed`, `count` | View reminders (default: incomplete only, max 50) |
+| `create_reminder` | `title` | `list`, `due_date`, `due_time`, `priority`, `notes` | Create a new reminder |
+| `update_reminder` | `title` | `list`, `new_title`, `due_date`, `due_time`, `priority`, `notes`, `clear_due_date` | Update an existing reminder (found by title) |
+| `complete_reminder` | `title` | `list` | Mark a reminder as done |
+| `search_reminders` | `query` | `list`, `include_completed`, `count` | Search across reminder names and notes |
+
+Priority levels: `none` (default), `low`, `medium`, `high`.
+
+### Setup
+
+```bash
+npm run setup:reminders-helper   # Compile Swift, create app bundle, codesign
+```
+
+First run requires granting Reminders permission. TCC rebuild behavior is the same as Calendar — see the Calendar TCC section above.
+
+### Swift Source
+
+`src/swift/chris-reminders.swift`. Commands: `list-lists`, `get-reminders`, `create-reminder`, `update-reminder`, `complete-reminder`, `search-reminders`. Outputs JSON `{ok, data, error}` to stdout.
 
 ## Files
 
@@ -133,5 +170,7 @@ AppleScript is written to temp files and executed via `/usr/bin/osascript` (mult
 |------|---------|
 | `src/tools/macos.ts` | Tool registration + execution logic (Node.js wrapper) |
 | `src/swift/chris-calendar.swift` | Swift EventKit CLI source (~430 lines) |
+| `src/swift/chris-reminders.swift` | Swift EventKit CLI source for Reminders |
 | `scripts/setup-calendar-helper.sh` | Build + install script (`npm run setup:calendar-helper`) |
-| `~/.chris-assistant/ChrisCalendar.app` | Installed app bundle (not in repo) |
+| `~/.chris-assistant/ChrisCalendar.app` | Installed Calendar app bundle (not in repo) |
+| `~/.chris-assistant/ChrisReminders.app` | Installed Reminders app bundle (not in repo) |

--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -34,12 +34,15 @@ The assistant has access to a set of tools that all providers pick up automatica
 | `run_skill` | Always | Execute a skill by ID with optional inputs |
 | `ssh` | Always | SSH into Tailnet devices — 9 actions ([full guide](/tools/ssh)) |
 | `market_snapshot` | Always | SSH to Mac Mini to run tasty-coach for market data |
-| `macos_calendar` | Always | macOS Calendar via native EventKit — list, get, add, delete events (~300ms) |
-| `macos_mail` | Always | macOS Mail via AppleScript — inbox summary, recent messages, search |
+| `browse_url` | Always | Browse a URL with headless Chromium (JS rendering). Use when `fetch_url` returns empty/broken content |
+| `get_usage_report` | Always | Token usage and cost report — today or multi-day summary |
+| `macos_calendar` | Always | macOS Calendar via native EventKit — list, get, add, update, delete, search events (~300ms) |
+| `macos_mail` | Always | macOS Mail via AppleScript — summary, inbox, search, read, reply, delete, move, mark, list mailboxes |
+| `macos_reminders` | Always | macOS Reminders via native EventKit — list, create, update, complete, search reminders |
 
 **"Always"** tools are available in every conversation. **"Coding"** tools are only sent when a project workspace is active (set via `/project` command or `WORKSPACE_ROOT` env var).
 
-The `macos_calendar` and `macos_mail` tools are **macOS-only** — they only register when `process.platform === "darwin"`. See [macOS tools guide](macos.md) for setup and TCC permissions.
+The `macos_calendar`, `macos_mail`, and `macos_reminders` tools are **macOS-only** — they only register when `process.platform === "darwin"`. See [macOS tools guide](macos.md) for setup and TCC permissions.
 
 ## Skills vs Tools
 


### PR DESCRIPTION
## Summary
- Add 6 missing env vars to README (CLAUDE_MODEL, IMAGE_MODEL, MAX_TOOL_TURNS, etc.)
- Add `src/swift/` to architecture section, fix config path references
- Document all 9 `macos_mail` actions (was only 3 after the reply/delete/move expansion)
- Add `macos_reminders`, `browse_url`, and `get_usage_report` to tools docs
- Rewrite `token-usage-tracking.md` from stale proposal to implementation doc
- Add macOS tools page to VitePress sidebar

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Verify docs build with `npm run docs:build` if available
- [ ] Spot-check that new tool entries match actual codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)