### PR TITLE
docs: webhook server, service registry, skills guide, and cleanup

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
         text: 'Channels',
         items: [
           { text: 'Discord Setup', link: '/discord-setup' },
+          { text: 'Webhook Server', link: '/webhook' },
         ],
       },
       {
@@ -68,6 +69,12 @@ export default defineConfig({
         items: [
           { text: 'Command Reference', link: '/cli/reference' },
           { text: 'Environment & Config', link: '/cli/environment' },
+        ],
+      },
+      {
+        text: 'Skills',
+        items: [
+          { text: 'Skills Guide', link: '/skills-guide' },
         ],
       },
       {

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -103,3 +103,31 @@ User sends Telegram or Discord message
   │
   └── Channel-specific output formatting / streaming
 ```
+
+## Service Registry
+
+Background services are registered as `AppService` entries in `src/app/service-definitions.ts`. Each service implements a `start()` / `stop()` pair and is managed by a `ServiceRegistry` that starts them in order and stops them in reverse order on shutdown.
+
+Services are split into two registries based on boot timing:
+
+- **Pre-Telegram** -- runs before the Telegram bot connects (e.g. setting the command menu)
+- **Post-Telegram** -- runs after the bot is online
+
+| Service | Purpose |
+|---------|---------|
+| `telegram-command-menu` | Sets the Telegram `/` command menu |
+| `health-monitor` | Periodic health checks |
+| `scheduler` | Cron-style scheduled task execution |
+| `conversation-backup` | Backs up conversation history |
+| `archive-uploader` | Uploads daily JSONL archives to GitHub |
+| `daily-summarizer` | Generates daily conversation summaries |
+| `channel-summarizer` | Weekly per-channel Discord summaries |
+| `journal-uploader` | Uploads the bot's daily journal |
+| `memory-consolidation` | Consolidates memory files periodically |
+| `heartbeat` | Writes `HEARTBEAT.md` status to memory repo |
+| `dashboard` | HTTP dashboard server |
+| `discord` | Discord bot client |
+| `webhook` | GitHub webhook server for PR notifications |
+| `usage-report` | Daily token usage report |
+
+To add a new background service, create a module with `start*()` / `stop*()` exports and add a `createService()` entry to the appropriate registry in `service-definitions.ts`.

--- a/docs/roadmap/bot-skills-system.md
+++ b/docs/roadmap/bot-skills-system.md
@@ -1,6 +1,8 @@
 # Bot Skills System — Implementation Plan
 
 > **Status: Implemented** — PRs #24 (core infrastructure), #25 (system prompt integration), #26 (documentation) merged 2026-03-03.
+>
+> **This is a historical planning document.** For usage instructions, see the [Skills Guide](/skills-guide).
 
 ## Context
 

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -1,0 +1,120 @@
+# Skills Guide
+
+## What Are Skills?
+
+Skills are reusable workflows defined as JSON. They compose existing bot tools into higher-level capabilities without writing any code. Skills are stored in the GitHub memory repo and can be created, edited, and deleted at runtime through conversation.
+
+**Example use cases**: "Check Hacker News top stories", "Generate a weekly project status report", "Summarize my unread emails".
+
+## How Skills Work
+
+1. **Discovery** -- The skill index is loaded into the system prompt. The AI sees available skills and their trigger phrases.
+2. **Execution** -- When triggered, `run_skill` loads the full definition, validates inputs, substitutes placeholders, and runs a focused AI call with only the skill's declared tools.
+3. **Management** -- The `manage_skills` tool handles CRUD. No restart needed.
+
+## Skill JSON Format
+
+```json
+{
+  "id": "check-hn",
+  "name": "Check Hacker News",
+  "description": "Fetch and summarize top stories from Hacker News",
+  "version": 1,
+  "enabled": true,
+  "createdAt": 1709510400000,
+  "updatedAt": 1709510400000,
+  "triggers": ["check hacker news", "what's on HN", "tech news"],
+  "tools": ["fetch_url"],
+  "inputs": {
+    "count": {
+      "type": "number",
+      "description": "Number of stories to fetch",
+      "default": 5
+    }
+  },
+  "instructions": "1. Fetch https://hacker-news.firebaseio.com/v0/topstories.json\n2. Take the first {count} story IDs\n3. Fetch each story's details\n4. Summarize with title, points, and URL",
+  "outputFormat": "telegram",
+  "state": {}
+}
+```
+
+### Field Reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | URL-safe lowercase slug (letters, digits, hyphens). Used as the filename. |
+| `name` | Yes | Human-readable name. |
+| `description` | Yes | Short summary of what the skill does. |
+| `instructions` | Yes | Step-by-step prompt with `{inputName}` placeholders. Max 5000 chars. |
+| `tools` | Yes | Array of registered tool names the skill may use. Validated at creation. |
+| `triggers` | No | Phrases the AI recognizes as wanting this skill. |
+| `inputs` | No | Typed parameters (`string`, `number`, `boolean`) with optional defaults. |
+| `outputFormat` | No | Format hint for the output (default: `"telegram"`). |
+| `state` | No | Persistent key-value data across invocations. Max 10 KB. |
+
+## Create Your First Skill
+
+The easiest way is to ask the bot directly:
+
+> "Create a skill called 'Check Hacker News' that fetches the top stories from the HN API and summarizes them. It should use the fetch_url tool and accept a count parameter."
+
+The AI will call `manage_skills` with action `create` and fill in the fields for you.
+
+You can also be explicit about the parameters:
+
+> "Create a skill with these details:
+> - Name: Daily Weather
+> - Description: Fetch current weather for a given city
+> - Tools: fetch_url
+> - Inputs: city (string, required)
+> - Instructions: Fetch weather from wttr.in/{city}?format=j1 and summarize the current conditions
+> - Triggers: weather, what's the weather"
+
+## Managing Skills
+
+All management happens through the `manage_skills` tool:
+
+| Action | What it does |
+|--------|-------------|
+| `create` | Create a new skill. |
+| `list` | Show all skills with status and triggers. |
+| `get` | View the full JSON definition of a skill. |
+| `update` | Modify fields on an existing skill (bumps version). |
+| `delete` | Remove a skill permanently. |
+| `toggle` | Enable or disable a skill. |
+| `update_state` | Merge data into a skill's persistent state. |
+
+**Examples**:
+- "List my skills"
+- "Disable the check-hn skill"
+- "Update the weather skill to also include the forecast"
+- "Delete the old market-report skill"
+
+## Running Skills
+
+Use `run_skill` directly or just use a trigger phrase:
+
+- "Run the check-hn skill with count 10"
+- "Check hacker news" (matches trigger phrase)
+
+Skills also compose with the scheduler. A scheduled task can reference a skill:
+
+> "Every morning at 8am, run the daily-weather skill for London"
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Max skills | 50 |
+| Max instruction length | 5000 chars |
+| Max state size | 10 KB |
+| Tool validation | Must be registered tool names |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/skills/loader.ts` | GitHub-backed CRUD with 5-min index cache |
+| `src/skills/validator.ts` | Definition and input validation |
+| `src/skills/executor.ts` | Placeholder substitution, nested `chat()` execution |
+| `src/tools/skills.ts` | `manage_skills` + `run_skill` tool registration |

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -1,0 +1,50 @@
+# Webhook Server
+
+## Overview
+
+The webhook server listens for GitHub webhook events and posts notifications to Discord. It runs as a separate HTTP server alongside the main bot and dashboard.
+
+Currently it handles one event: **PR merge notifications**. When a pull request is merged, it formats a summary and posts it to the `#pr-reviews` Discord channel.
+
+## Configuration
+
+| Env Var | Required | Default | Description |
+|---------|----------|---------|-------------|
+| `GITHUB_WEBHOOK_SECRET` | Yes | — | HMAC-SHA256 secret configured in your GitHub webhook settings. Server won't start without it. |
+| `WEBHOOK_PORT` | No | `3001` | Port the webhook server listens on. |
+
+The webhook endpoint is `POST /webhooks/github`. A health check is available at `GET /health`.
+
+## GitHub Setup
+
+1. Go to your repo's Settings > Webhooks > Add webhook
+2. Set **Payload URL** to `https://your-server:3001/webhooks/github`
+3. Set **Content type** to `application/json`
+4. Set **Secret** to match your `GITHUB_WEBHOOK_SECRET` env var
+5. Select "Let me select individual events" and check **Pull requests**
+
+## Events Handled
+
+| GitHub Event | Action | Behavior |
+|-------------|--------|----------|
+| `ping` | — | Logs confirmation, no Discord message |
+| `pull_request` | `closed` + `merged: true` | Formats and posts merge notification to Discord |
+| `pull_request` | Any other action | Ignored |
+| Any other event | — | Ignored |
+
+## Security
+
+- All payloads are verified against the `x-hub-signature-256` header using HMAC-SHA256 with timing-safe comparison
+- Request bodies are capped at 1 MB
+- Discord mentions (`@everyone`, `@here`, user/role pings) are stripped from PR titles and bodies before posting
+
+## Integration
+
+The webhook server is registered as a background service in the service registry and follows the standard `start*()`/`stop*()` lifecycle. It starts automatically on boot if `GITHUB_WEBHOOK_SECRET` is set.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/webhook.ts` | Server implementation, signature verification, message formatting |
+| `src/infra/config/schema.ts` | Env var validation for `GITHUB_WEBHOOK_SECRET` and `WEBHOOK_PORT` |


### PR DESCRIPTION
## Summary
- Add webhook server docs (GitHub PR events, HMAC security, config)
- Document `AppService` registry pattern with table of all 14 services
- Add skills creation guide (JSON format, walkthrough, management, scheduling)
- Mark bot-skills-system roadmap as historical with pointer to new guide
- VitePress sidebar reorganised with Webhook and Skills sections

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run docs:build` passes
- [ ] All new sidebar links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)