### PR TITLE
fix: raise mail loop guard to 250 and reset per user message

### DIFF
--- a/src/agent/chat-service.ts
+++ b/src/agent/chat-service.ts
@@ -6,6 +6,7 @@ import { createCodexAgentProvider, abortCodexQuery } from "../providers/codex-ag
 import { createMiniMaxProvider } from "../providers/minimax.js";
 import { isOpenAiModel, isMiniMaxModel, isClaudeModel, isCodexAgentModel } from "../providers/model-routing.js";
 import { createOpenAiProvider } from "../providers/openai.js";
+import { resetLoopDetection } from "../tools/index.js";
 import type { Provider, ImageAttachment } from "../providers/types.js";
 
 export interface ChatRequest {
@@ -46,6 +47,11 @@ export class ChatService {
   }
 
   async sendMessage({ chatId, userMessage, onChunk, images, allowedTools }: ChatRequest): Promise<string> {
+    // Reset loop-guard counters at the start of each new user turn so the
+    // frequency limit protects against runaway loops within a single AI
+    // response, not across the entire conversation.
+    resetLoopDetection();
+
     if (images && images.length > 0) {
       const imageModel = config.imageModel;
       console.log("[provider] %d image(s) detected — routing to image model: %s", images.length, imageModel);

--- a/src/tools/macos.ts
+++ b/src/tools/macos.ts
@@ -636,7 +636,7 @@ registerTool({
 registerTool({
   name: "macos_mail",
   category: "always",
-  frequencyLimit: 100,
+  frequencyLimit: 250,
   description:
     `Interact with macOS Mail app (default account: ${DEFAULT_MAIL_ACCOUNT}). ` +
     "Actions: summary, inbox, search, read, reply, delete, move, mark, list_mailboxes. " +


### PR DESCRIPTION
## Summary
- Raise `macos_mail` frequency limit from 100 to 250 (supports ~60-80 email batch operations)
- Reset loop detection counters at start of each user message (`sendMessage()`) so limits don't accumulate across conversation turns
- Existing per-response protection unchanged — still catches runaway tool loops within a single AI response

## Context
User hit the 100-call limit while triaging ~99 emails in a single conversation. The counter was accumulating across the entire conversation rather than resetting between user messages.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (91 tests)
- [ ] Verify mail-heavy conversation can exceed 250 calls across multiple user messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)