### PR TITLE
feat: add GraphQL balance/bills and compare action to octopus_energy

### DIFF
--- a/src/tools/octopus-energy.ts
+++ b/src/tools/octopus-energy.ts
@@ -7,10 +7,12 @@ import { config } from "../config.js";
 // ---------------------------------------------------------------------------
 
 const BASE_URL = "https://api.octopus.energy";
+const GRAPHQL_URL = "https://api.octopus.energy/v1/graphql/";
 const GAS_VOLUME_CORRECTION = 1.02264;
 const GAS_CALORIFIC_VALUE = 39.5;
 const GAS_KWH_DIVISOR = 3.6;
 const FETCH_TIMEOUT_MS = 15_000;
+const GRAPHQL_TOKEN_LIFETIME_MS = 55 * 60 * 1000; // 55 minutes (tokens last 60)
 
 // ---------------------------------------------------------------------------
 // Auth helper
@@ -56,6 +58,91 @@ async function octopusFetch(
     }
 
     return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL token management
+// ---------------------------------------------------------------------------
+
+let graphqlToken: string | null = null;
+let graphqlTokenExpiresAt = 0;
+
+async function ensureGraphqlToken(apiKey: string): Promise<string> {
+  if (graphqlToken && Date.now() < graphqlTokenExpiresAt - 60_000) {
+    return graphqlToken;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(GRAPHQL_URL, {
+      method: "POST",
+      signal: controller.signal,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: `mutation { obtainKrakenToken(input: { APIKey: "${apiKey}" }) { token } }`,
+      }),
+    });
+
+    const json = await res.json();
+    const token = json?.data?.obtainKrakenToken?.token;
+    if (!token) {
+      const errMsg = json?.errors?.[0]?.message ?? "Unknown GraphQL auth error";
+      throw new Error(`GraphQL auth failed: ${errMsg}`);
+    }
+
+    graphqlToken = token;
+    graphqlTokenExpiresAt = Date.now() + GRAPHQL_TOKEN_LIFETIME_MS;
+    return token;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function graphqlQuery(
+  apiKey: string,
+  query: string,
+  variables?: Record<string, unknown>,
+  _isRetry = false,
+): Promise<any> {
+  const token = await ensureGraphqlToken(apiKey);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(GRAPHQL_URL, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: token,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    const json = await res.json();
+
+    // Check for auth errors and retry once with a fresh token
+    const errors = json?.errors ?? [];
+    const isAuthError = errors.some(
+      (e: any) => e?.extensions?.errorType === "AUTHORIZATION",
+    );
+    if (isAuthError && !_isRetry) {
+      graphqlToken = null;
+      graphqlTokenExpiresAt = 0;
+      return graphqlQuery(apiKey, query, variables, true);
+    }
+
+    if (errors.length > 0 && !json?.data) {
+      throw new Error(`GraphQL error: ${errors[0]?.message ?? "Unknown error"}`);
+    }
+
+    return json.data;
   } finally {
     clearTimeout(timer);
   }
@@ -387,6 +474,20 @@ async function handleSummary(apiKey: string, accountNumber: string): Promise<str
 
   lines.push(`**Total est. cost today: \u00A3${totalCostPounds.toFixed(2)}**`);
 
+  // Append account balance from GraphQL
+  try {
+    const balancePence = await fetchAccountBalance(apiKey, accountNumber);
+    if (balancePence != null) {
+      const balanceStr = formatPence(balancePence);
+      const label = balancePence >= 0 ? "in credit" : "owed";
+      lines.push("");
+      lines.push(`**Account balance: ${balanceStr} (${label})**`);
+    }
+  } catch {
+    lines.push("");
+    lines.push("**Account balance: unavailable**");
+  }
+
   return lines.join("\n");
 }
 
@@ -544,6 +645,241 @@ async function handleTariff(apiKey: string, accountNumber: string): Promise<stri
 }
 
 // ---------------------------------------------------------------------------
+// GraphQL helpers
+// ---------------------------------------------------------------------------
+
+async function fetchAccountBalance(apiKey: string, accountNumber: string): Promise<number | null> {
+  try {
+    const data = await graphqlQuery(apiKey, `
+      query($account: String!) {
+        account(accountNumber: $account) {
+          balance
+        }
+      }
+    `, { account: accountNumber });
+    const balance = data?.account?.balance;
+    return typeof balance === "number" ? balance : null;
+  } catch (err: any) {
+    console.error(`[octopus] Failed to fetch account balance: ${err.message}`);
+    return null;
+  }
+}
+
+function formatPence(pence: number): string {
+  const pounds = pence / 100;
+  const sign = pounds < 0 ? "-" : "";
+  return `${sign}\u00A3${Math.abs(pounds).toFixed(2)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Bills handler
+// ---------------------------------------------------------------------------
+
+async function handleBills(apiKey: string, accountNumber: string): Promise<string> {
+  const data = await graphqlQuery(apiKey, `
+    query($account: String!) {
+      account(accountNumber: $account) {
+        balance
+        bills(first: 10) {
+          edges {
+            node {
+              ... on StatementType {
+                id
+                fromDate
+                toDate
+                issuedDate
+                closingBalance
+                openingBalance
+              }
+            }
+          }
+        }
+      }
+    }
+  `, { account: accountNumber });
+
+  const account = data?.account;
+  if (!account) {
+    return "Error: Could not retrieve account data via GraphQL.";
+  }
+
+  const lines: string[] = [];
+
+  // Account balance (in pence)
+  const balance: number | null = typeof account.balance === "number" ? account.balance : null;
+  if (balance != null) {
+    const balanceStr = formatPence(balance);
+    const label = balance >= 0 ? "in credit" : "owed";
+    lines.push(`**Account Balance**: ${balanceStr} (${label})`);
+  } else {
+    lines.push("**Account Balance**: unavailable");
+  }
+  lines.push("");
+
+  // Recent bills
+  const edges = account.bills?.edges ?? [];
+  if (edges.length === 0) {
+    lines.push("**Recent Bills**: none found");
+  } else {
+    lines.push("**Recent Bills**");
+    for (const edge of edges) {
+      const bill = edge?.node;
+      if (!bill) continue;
+
+      const fromDate = bill.fromDate
+        ? new Date(bill.fromDate).toLocaleDateString("en-GB", { dateStyle: "medium" })
+        : "?";
+      const toDate = bill.toDate
+        ? new Date(bill.toDate).toLocaleDateString("en-GB", { dateStyle: "medium" })
+        : "?";
+      const issuedDate = bill.issuedDate
+        ? new Date(bill.issuedDate).toLocaleDateString("en-GB", { dateStyle: "medium" })
+        : "";
+
+      const parts = [`  ${fromDate} - ${toDate}`];
+      if (issuedDate) parts.push(`issued ${issuedDate}`);
+      if (typeof bill.openingBalance === "number" && typeof bill.closingBalance === "number") {
+        parts.push(`opening ${formatPence(bill.openingBalance)}, closing ${formatPence(bill.closingBalance)}`);
+      }
+      lines.push(parts.join(" | "));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Compare handler
+// ---------------------------------------------------------------------------
+
+function mondayOfWeek(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay(); // 0=Sun, 1=Mon, ...
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+async function handleCompare(
+  apiKey: string,
+  accountNumber: string,
+  periodFrom?: string,
+  periodTo?: string,
+  compareFrom?: string,
+  compareTo?: string,
+  fuel?: string,
+): Promise<string> {
+  const account = await ensureAccountData(apiKey, accountNumber);
+  const fuelFilter = fuel ?? "both";
+
+  // Default current period: this week (Mon-Sun)
+  const now = new Date();
+  const currentFrom = periodFrom
+    ? new Date(toISODatetime(periodFrom))
+    : mondayOfWeek(now);
+  const currentTo = periodTo
+    ? new Date(toISODatetime(periodTo))
+    : addDays(mondayOfWeek(now), 7);
+
+  const periodLengthMs = currentTo.getTime() - currentFrom.getTime();
+  const periodLengthDays = Math.max(1, Math.round(periodLengthMs / (24 * 60 * 60 * 1000)));
+
+  // Default comparison period: previous week (same length)
+  const compFrom = compareFrom
+    ? new Date(toISODatetime(compareFrom))
+    : new Date(currentFrom.getTime() - periodLengthMs);
+  const compTo = compareTo
+    ? new Date(toISODatetime(compareTo))
+    : new Date(currentTo.getTime() - periodLengthMs);
+
+  const currentFromISO = currentFrom.toISOString();
+  const currentToISO = currentTo.toISOString();
+  const compFromISO = compFrom.toISOString();
+  const compToISO = compTo.toISOString();
+
+  const lines: string[] = ["**Energy Comparison**", ""];
+
+  let totalCostCurrent = 0;
+  let totalCostPrevious = 0;
+
+  const fuels: Array<{ key: "electricity" | "gas"; label: string; meter: MeterInfo | null }> = [];
+  if (fuelFilter === "both" || fuelFilter === "electricity") {
+    fuels.push({ key: "electricity", label: "Electricity", meter: account.electricity });
+  }
+  if (fuelFilter === "both" || fuelFilter === "gas") {
+    fuels.push({ key: "gas", label: "Gas", meter: account.gas });
+  }
+
+  for (const { key, label, meter } of fuels) {
+    if (!meter) {
+      lines.push(`**${label}**: No meter found on account`);
+      lines.push("");
+      continue;
+    }
+
+    const productCode = extractProductCode(meter.tariffCode);
+
+    const [currentConsumption, previousConsumption, rates] = await Promise.all([
+      fetchConsumption(apiKey, meter, key, currentFromISO, currentToISO).catch(() => []),
+      fetchConsumption(apiKey, meter, key, compFromISO, compToISO).catch(() => []),
+      fetchTariffRates(apiKey, productCode, meter.tariffCode, key).catch(
+        () => ({ unitRate: null, standingCharge: null, upcomingRates: [] }),
+      ),
+    ]);
+
+    const currentKwh = currentConsumption.reduce((s, r) => s + r.consumption, 0);
+    const previousKwh = previousConsumption.reduce((s, r) => s + r.consumption, 0);
+
+    // Cost calculation: unit cost + standing charges for the period
+    const unitRatePounds = (rates.unitRate ?? 0) / 100;
+    const standingDailyPounds = (rates.standingCharge ?? 0) / 100;
+
+    const currentCost = currentKwh * unitRatePounds + standingDailyPounds * periodLengthDays;
+    const previousCost = previousKwh * unitRatePounds + standingDailyPounds * periodLengthDays;
+    totalCostCurrent += currentCost;
+    totalCostPrevious += previousCost;
+
+    const kwhDiff = currentKwh - previousKwh;
+    const kwhPct = previousKwh > 0 ? (kwhDiff / previousKwh) * 100 : 0;
+    const sign = kwhDiff >= 0 ? "+" : "";
+
+    lines.push(`**${label}**`);
+    lines.push(`  This period: ${currentKwh.toFixed(1)} kWh (\u00A3${currentCost.toFixed(2)})`);
+    lines.push(`  Last period: ${previousKwh.toFixed(1)} kWh (\u00A3${previousCost.toFixed(2)})`);
+    lines.push(`  Change: ${sign}${kwhDiff.toFixed(1)} kWh (${sign}${kwhPct.toFixed(1)}%)`);
+
+    if (currentConsumption.length === 0) {
+      lines.push("  (No data for current period -- smart meter data has a 24-48h delay)");
+    }
+    if (previousConsumption.length === 0) {
+      lines.push("  (No data for comparison period)");
+    }
+    lines.push("");
+  }
+
+  // Total cost change
+  const costDiff = totalCostCurrent - totalCostPrevious;
+  const costPct = totalCostPrevious > 0 ? (costDiff / totalCostPrevious) * 100 : 0;
+  const costSign = costDiff >= 0 ? "+" : "";
+  lines.push(`**Total cost change: ${costSign}\u00A3${Math.abs(costDiff).toFixed(2)} (${costSign}${costPct.toFixed(1)}%)**`);
+
+  // Add period labels
+  const fmtDate = (d: Date) => d.toLocaleDateString("en-GB", { dateStyle: "medium" });
+  lines.push("");
+  lines.push(`Current period: ${fmtDate(currentFrom)} - ${fmtDate(currentTo)}`);
+  lines.push(`Comparison period: ${fmtDate(compFrom)} - ${fmtDate(compTo)}`);
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
 // Tool registration
 // ---------------------------------------------------------------------------
 
@@ -552,14 +888,17 @@ registerTool({
   category: "always",
   description:
     "Query Octopus Energy account data. " +
-    "Actions: summary (today's usage + costs), usage (consumption data for a period), tariff (current rates). " +
+    "Actions: summary (today's usage + costs + balance), usage (consumption data for a period), " +
+    "tariff (current rates), bills (account balance + recent bills), compare (compare two periods). " +
     "Requires OCTOPUS_API_KEY and OCTOPUS_ACCOUNT_NUMBER env vars.",
   zodSchema: {
-    action: z.enum(["summary", "usage", "tariff"]),
+    action: z.enum(["summary", "usage", "tariff", "bills", "compare"]),
     period_from: z.string().optional().describe("ISO 8601 date, e.g. 2026-03-14"),
     period_to: z.string().optional().describe("ISO 8601 date, e.g. 2026-03-15"),
     group_by: z.enum(["half_hour", "hour", "day", "week", "month"]).optional(),
     fuel: z.enum(["electricity", "gas", "both"]).optional(),
+    compare_from: z.string().optional().describe("Start of comparison period, ISO 8601 date"),
+    compare_to: z.string().optional().describe("End of comparison period, ISO 8601 date"),
   },
   jsonSchemaParameters: {
     type: "object",
@@ -567,19 +906,21 @@ registerTool({
     properties: {
       action: {
         type: "string",
-        enum: ["summary", "usage", "tariff"],
+        enum: ["summary", "usage", "tariff", "bills", "compare"],
         description:
           "summary: today's electricity + gas usage, costs, and current rates. " +
           "usage: consumption data for a date range (defaults to today, grouped by day). " +
-          "tariff: current tariff codes, unit rates, and standing charges.",
+          "tariff: current tariff codes, unit rates, and standing charges. " +
+          "bills: account balance and recent billing statements. " +
+          "compare: compare energy usage between two periods (defaults to this week vs last week).",
       },
       period_from: {
         type: "string",
-        description: "Start date in ISO 8601 format, e.g. 2026-03-14. Defaults to start of today.",
+        description: "Start date in ISO 8601 format, e.g. 2026-03-14. Defaults to start of today (or this Monday for compare).",
       },
       period_to: {
         type: "string",
-        description: "End date in ISO 8601 format, e.g. 2026-03-15. Defaults to now.",
+        description: "End date in ISO 8601 format, e.g. 2026-03-15. Defaults to now (or this Sunday for compare).",
       },
       group_by: {
         type: "string",
@@ -591,6 +932,14 @@ registerTool({
         enum: ["electricity", "gas", "both"],
         description: "Which fuel to query. Defaults to both.",
       },
+      compare_from: {
+        type: "string",
+        description: "Start of comparison period in ISO 8601 format. Defaults to previous week.",
+      },
+      compare_to: {
+        type: "string",
+        description: "End of comparison period in ISO 8601 format. Defaults to same length as current period.",
+      },
     },
   },
   execute: async (args: any): Promise<string> => {
@@ -601,7 +950,7 @@ registerTool({
       return "Error: Octopus Energy not configured. Set OCTOPUS_API_KEY and OCTOPUS_ACCOUNT_NUMBER environment variables.";
     }
 
-    const { action, period_from, period_to, group_by, fuel } = args;
+    const { action, period_from, period_to, group_by, fuel, compare_from, compare_to } = args;
 
     try {
       switch (action) {
@@ -613,6 +962,14 @@ registerTool({
 
         case "tariff":
           return await handleTariff(apiKey, accountNumber);
+
+        case "bills":
+          return await handleBills(apiKey, accountNumber);
+
+        case "compare":
+          return await handleCompare(
+            apiKey, accountNumber, period_from, period_to, compare_from, compare_to, fuel,
+          );
 
         default:
           return `Unknown action: ${action}`;


### PR DESCRIPTION
## Summary
- GraphQL JWT token management (auto-refresh, retry on auth failure)
- `bills` action: account balance + last 10 statements
- Account balance appended to `summary` (graceful fallback)
- `compare` action: period-over-period usage + cost comparison with % changes

## Phase 2 of 3
Phase 1 (merged): summary, usage, tariff via REST
Phase 3 (next): scheduled daily Telegram report

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (91 tests)
- [ ] Manual test: "what's my account balance?"
- [ ] Manual test: "compare my energy usage this week vs last week"
- [ ] Manual test: "show me my recent bills"

🤖 Generated with [Claude Code](https://claude.com/claude-code)