### PR TITLE
feat: Sonnet-powered memory recall with dual-write persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+        "@anthropic-ai/sdk": "^0.52.0",
         "@mozilla/readability": "^0.6.0",
         "@octokit/rest": "^21.0.0",
         "@openai/codex-sdk": "^0.111.0",
@@ -313,6 +314,15 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.52.0.tgz",
+      "integrity": "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "@anthropic-ai/sdk": "^0.52.0",
     "@mozilla/readability": "^0.6.0",
     "@octokit/rest": "^21.0.0",
     "@openai/codex-sdk": "^0.111.0",

--- a/scripts/backfill-local-memory.ts
+++ b/scripts/backfill-local-memory.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env npx tsx
+/**
+ * One-time backfill: pull existing data from the GitHub memory repo and
+ * write local recall files so the Sonnet recall system has historical context.
+ *
+ * Backfills:
+ *   1. All daily conversation summaries → memory/summaries/{date}.md
+ *   2. Current knowledge files (USER.md) → memory/ topic files
+ *   3. Current memory files (learnings.md) → memory/ topic files
+ *
+ * Safe to run multiple times — overwrites existing local files.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-local-memory.ts
+ */
+
+import "dotenv/config";
+import { mkdir, writeFile } from "fs/promises";
+import * as path from "path";
+import { listMemoryDir, readMemoryFile } from "../src/domain/memory/repository.js";
+
+const MEMORY_DIR = path.join(
+  process.env.HOME || "/Users/christaylor",
+  "Projects/chris-assistant/memory",
+);
+
+const SUMMARIES_DIR = path.join(MEMORY_DIR, "summaries");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function slugify(text: string): string {
+  return text
+    .slice(0, 60)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .slice(0, 40) || "entry";
+}
+
+function firstLine(text: string): string {
+  const line = text
+    .split("\n")
+    .find((l) => l.trim().length > 0 && !l.startsWith("#") && !l.startsWith("<!--"))
+    || text.split("\n").find((l) => l.trim().length > 0)
+    || "";
+  const cleaned = line.replace(/^[-*•#]\s*/g, "").replace(/\*\*/g, "").trim();
+  return cleaned.length > 120 ? cleaned.slice(0, 117) + "..." : cleaned;
+}
+
+async function writeLocalFile(filePath: string, content: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Backfill summaries
+// ---------------------------------------------------------------------------
+
+async function backfillSummaries(): Promise<number> {
+  console.log("\n📦 Backfilling daily conversation summaries...");
+
+  const files = await listMemoryDir("conversations/summaries");
+  if (files.length === 0) {
+    console.log("   No summaries found in repo.");
+    return 0;
+  }
+
+  console.log("   Found %d summary files in GitHub repo", files.length);
+  let count = 0;
+
+  for (const repoPath of files) {
+    const filename = path.basename(repoPath);
+    const date = filename.replace(".md", "");
+
+    const content = await readMemoryFile(repoPath);
+    if (!content) continue;
+
+    const description = firstLine(content.replace(/^#.*\n+/, ""));
+    const localPath = path.join(SUMMARIES_DIR, filename);
+
+    const fileContent = `---
+name: conversation summary ${date}
+description: ${description}
+type: reference
+---
+
+${content}
+`;
+    await writeLocalFile(localPath, fileContent);
+    count++;
+    process.stdout.write(`   ✓ ${date}\n`);
+  }
+
+  console.log("   Wrote %d summary files", count);
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Backfill knowledge files (USER.md → individual entries)
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a monolithic memory file (USER.md, learnings.md) into individual
+ * topic files based on <!-- Updated: YYYY-MM-DD --> markers.
+ */
+function splitByTimestampMarkers(
+  content: string,
+  category: string,
+  type: string,
+): Array<{ filename: string; content: string }> {
+  // Split on the timestamp comment markers that update_memory adds
+  const chunks = content.split(/(?=<!-- Updated: \d{4}-\d{2}-\d{2} -->)/);
+  const results: Array<{ filename: string; content: string }> = [];
+
+  for (const chunk of chunks) {
+    const trimmed = chunk.trim();
+    if (!trimmed || trimmed.length < 10) continue;
+
+    // Extract date from marker if present
+    const dateMatch = trimmed.match(/<!-- Updated: (\d{4}-\d{2}-\d{2}) -->/);
+    const date = dateMatch ? dateMatch[1] : "unknown";
+
+    // Content without the marker
+    const body = trimmed.replace(/<!-- Updated: \d{4}-\d{2}-\d{2} -->\s*/, "").trim();
+    if (!body) continue;
+
+    const slug = slugify(body);
+    const description = firstLine(body);
+    const filename = `${category}_${date}_${slug}.md`;
+
+    const fileContent = `---
+name: ${category} — ${slug.replace(/-/g, " ")}
+description: ${description}
+type: ${type}
+---
+
+${body}
+`;
+    results.push({ filename, content: fileContent });
+  }
+
+  return results;
+}
+
+async function backfillKnowledgeFile(
+  repoPath: string,
+  category: string,
+  type: string,
+): Promise<number> {
+  const content = await readMemoryFile(repoPath);
+  if (!content) {
+    console.log("   %s: not found in repo", repoPath);
+    return 0;
+  }
+
+  const entries = splitByTimestampMarkers(content, category, type);
+  if (entries.length === 0) {
+    // No timestamp markers — write as single file
+    const slug = slugify(content);
+    const description = firstLine(content);
+    const filename = `${category}_bulk_${slug}.md`;
+    const localPath = path.join(MEMORY_DIR, filename);
+    const fileContent = `---
+name: ${category} — bulk import
+description: ${description}
+type: ${type}
+---
+
+${content}
+`;
+    await writeLocalFile(localPath, fileContent);
+    console.log("   %s: wrote 1 bulk file (no timestamp markers found)", repoPath);
+    return 1;
+  }
+
+  let count = 0;
+  for (const entry of entries) {
+    const localPath = path.join(MEMORY_DIR, entry.filename);
+    await writeLocalFile(localPath, entry.content);
+    count++;
+  }
+  console.log("   %s: wrote %d topic files", repoPath, count);
+  return count;
+}
+
+async function backfillKnowledge(): Promise<number> {
+  console.log("\n📦 Backfilling knowledge and memory files...");
+  let total = 0;
+  total += await backfillKnowledgeFile("USER.md", "about-chris", "user");
+  total += await backfillKnowledgeFile("memory/learnings.md", "learnings", "feedback");
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log("🔄 Backfilling local memory files for Sonnet recall");
+  console.log("   Source: GitHub memory repo");
+  console.log("   Target: %s", MEMORY_DIR);
+
+  await mkdir(MEMORY_DIR, { recursive: true });
+  await mkdir(SUMMARIES_DIR, { recursive: true });
+
+  const summaryCount = await backfillSummaries();
+  const knowledgeCount = await backfillKnowledge();
+
+  console.log("\n✅ Backfill complete: %d summary files + %d knowledge files", summaryCount, knowledgeCount);
+  console.log("   Sonnet recall will now have full historical context.");
+}
+
+main().catch((err) => {
+  console.error("❌ Backfill failed:", err.message);
+  process.exit(1);
+});

--- a/src/app/service-definitions.ts
+++ b/src/app/service-definitions.ts
@@ -12,6 +12,7 @@ import { startHeartbeat, stopHeartbeat } from "../heartbeat.js";
 import { startDashboard, stopDashboard } from "../dashboard.js";
 import { startWebhook, stopWebhook } from "../webhook.js";
 import { startUsageReport, stopUsageReport } from "../domain/usage/daily-report-service.js";
+import { ensureLocalMemoryDir } from "../domain/memory/recall.js";
 import { setTelegramCommandMenu } from "../channels/telegram/index.js";
 
 export function createPreTelegramRegistry(): ServiceRegistry {
@@ -28,6 +29,7 @@ export function createPreTelegramRegistry(): ServiceRegistry {
 
 export function createPostTelegramRegistry(): ServiceRegistry {
   return new ServiceRegistry([
+    createService("local-memory-dir", () => ensureLocalMemoryDir(), () => {}),
     createService("health-monitor", () => startHealthMonitor(), () => stopHealthMonitor()),
     createService("scheduler", () => startScheduler(), () => stopScheduler()),
     createService("conversation-backup", () => startConversationBackup(), () => stopConversationBackup()),

--- a/src/domain/conversations/daily-summary-service.ts
+++ b/src/domain/conversations/daily-summary-service.ts
@@ -1,6 +1,9 @@
+import { mkdir, writeFile } from "fs/promises";
+import * as path from "path";
 import { chatService } from "../../agent/chat-service.js";
 import { readMemoryFile, writeMemoryFile } from "../../memory/github.js";
 import { readLocalJournal } from "../../memory/journal.js";
+import { LOCAL_MEMORY_DIR } from "../memory/recall.js";
 import { datestamp, readLocalArchive } from "./archive-service.js";
 import type { ArchiveEntry } from "./types.js";
 
@@ -44,6 +47,38 @@ function formatArchiveForPrompt(entries: ArchiveEntry[]): string {
     .join("\n\n");
 }
 
+/**
+ * Dual-write: persist daily summary as a local recall file so Sonnet can
+ * surface conversation context beyond the 7-day always-loaded window.
+ */
+async function writeLocalSummaryFile(date: string, summary: string): Promise<void> {
+  try {
+    const summariesDir = path.join(LOCAL_MEMORY_DIR, "summaries");
+    await mkdir(summariesDir, { recursive: true });
+    const filename = `${date}.md`;
+    const filePath = path.join(summariesDir, filename);
+
+    // First line of summary as description
+    const firstLine = summary.split("\n").find((l) => l.trim().length > 0) || "";
+    const description = firstLine.length > 120 ? firstLine.slice(0, 117) + "..." : firstLine;
+
+    const fileContent = `---
+name: conversation summary ${date}
+description: ${description}
+type: reference
+---
+
+# Conversation Summary — ${date}
+
+${summary}
+`;
+    await writeFile(filePath, fileContent, "utf-8");
+    console.log("[summary] Local recall file written: summaries/%s", filename);
+  } catch (err: any) {
+    console.warn("[summary] Failed to write local recall file:", err instanceof Error ? err.message : err);
+  }
+}
+
 export async function generateSummary(date: string): Promise<string | null> {
   const entries = readLocalArchive(date);
   if (entries.length === 0) {
@@ -65,6 +100,11 @@ export async function generateSummary(date: string): Promise<string | null> {
 
   await writeMemoryFile(summaryRepoPath(date), `# Conversation Summary — ${date}\n\n${cleaned}`, `chore: daily summary ${date}`);
   console.log("[summary] Wrote summary for %s (%d chars)", date, cleaned.length);
+
+  // Dual-write: local recall file so Sonnet can surface old summaries
+  // beyond the 7-day always-loaded window.
+  writeLocalSummaryFile(date, cleaned).catch(() => {});
+
   return cleaned;
 }
 

--- a/src/domain/memory/memory-age.ts
+++ b/src/domain/memory/memory-age.ts
@@ -1,0 +1,37 @@
+/**
+ * Memory staleness detection.
+ *
+ * Provides human-readable age strings and freshness caveats for memory
+ * files. Models are poor at date arithmetic — "47 days ago" triggers
+ * staleness reasoning better than a raw ISO timestamp.
+ *
+ * Adapted from Claude Code's memoryAge.ts blueprint.
+ */
+
+/** Days elapsed since mtime. Floor-rounded, clamped to 0. */
+export function memoryAgeDays(mtimeMs: number): number {
+  return Math.max(0, Math.floor((Date.now() - mtimeMs) / 86_400_000));
+}
+
+/** Human-readable age string. */
+export function memoryAge(mtimeMs: number): string {
+  const d = memoryAgeDays(mtimeMs);
+  if (d === 0) return "today";
+  if (d === 1) return "yesterday";
+  return `${d} days ago`;
+}
+
+/**
+ * Staleness caveat for memories >1 day old.
+ * Returns empty string for fresh (today/yesterday) memories.
+ */
+export function memoryFreshnessText(mtimeMs: number): string {
+  const d = memoryAgeDays(mtimeMs);
+  if (d <= 1) return "";
+  return (
+    `This memory is ${d} days old. ` +
+    `Memories are point-in-time observations, not live state — ` +
+    `claims about code behavior or file:line citations may be outdated. ` +
+    `Verify against current code before asserting as fact.`
+  );
+}

--- a/src/domain/memory/memory-scan.ts
+++ b/src/domain/memory/memory-scan.ts
@@ -1,0 +1,111 @@
+/**
+ * Memory-directory scanning primitives.
+ *
+ * Scans a local memory/ directory for .md files, reads their YAML
+ * frontmatter headers, and returns a manifest for the recall selector.
+ *
+ * Adapted from Claude Code's memoryScan.ts blueprint.
+ */
+
+import { readdir, stat, readFile } from "fs/promises";
+import { basename, join } from "path";
+import { parse as parseYaml } from "yaml";
+
+export type MemoryType = "user" | "feedback" | "project" | "reference";
+
+export interface MemoryHeader {
+  filename: string;
+  filePath: string;
+  mtimeMs: number;
+  description: string | null;
+  type: MemoryType | undefined;
+}
+
+const MAX_MEMORY_FILES = 200;
+const FRONTMATTER_BYTES = 2048; // read first 2KB — enough for any frontmatter
+
+const VALID_TYPES = new Set<MemoryType>(["user", "feedback", "project", "reference"]);
+
+function parseMemoryType(raw: unknown): MemoryType | undefined {
+  if (typeof raw !== "string") return undefined;
+  return VALID_TYPES.has(raw as MemoryType) ? (raw as MemoryType) : undefined;
+}
+
+/**
+ * Parse YAML frontmatter from the beginning of a markdown file.
+ * Returns name, description, and type if present.
+ */
+function parseFrontmatter(content: string): { description?: string; type?: string } {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  try {
+    const parsed = parseYaml(match[1]);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    return {
+      description: typeof parsed.description === "string" ? parsed.description : undefined,
+      type: typeof parsed.type === "string" ? parsed.type : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Scan a memory directory for .md files, read their frontmatter, and return
+ * a header list sorted newest-first (capped at MAX_MEMORY_FILES).
+ * Skips MEMORY.md (the index file).
+ */
+export async function scanMemoryFiles(memoryDir: string): Promise<MemoryHeader[]> {
+  try {
+    const entries = await readdir(memoryDir, { recursive: true });
+    const mdFiles = entries.filter(
+      (f) => f.endsWith(".md") && basename(f) !== "MEMORY.md",
+    );
+
+    const headerResults = await Promise.allSettled(
+      mdFiles.map(async (relativePath): Promise<MemoryHeader> => {
+        const filePath = join(memoryDir, relativePath);
+        const [fileStat, buffer] = await Promise.all([
+          stat(filePath),
+          readFile(filePath, { encoding: "utf-8", flag: "r" }).then((s) =>
+            s.slice(0, FRONTMATTER_BYTES),
+          ),
+        ]);
+        const fm = parseFrontmatter(buffer);
+        return {
+          filename: relativePath,
+          filePath,
+          mtimeMs: fileStat.mtimeMs,
+          description: fm.description || null,
+          type: parseMemoryType(fm.type),
+        };
+      }),
+    );
+
+    return headerResults
+      .filter(
+        (r): r is PromiseFulfilledResult<MemoryHeader> => r.status === "fulfilled",
+      )
+      .map((r) => r.value)
+      .sort((a, b) => b.mtimeMs - a.mtimeMs)
+      .slice(0, MAX_MEMORY_FILES);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Format memory headers as a text manifest for the recall selector prompt.
+ * One line per file: [type] filename (timestamp): description
+ */
+export function formatMemoryManifest(memories: MemoryHeader[]): string {
+  return memories
+    .map((m) => {
+      const tag = m.type ? `[${m.type}] ` : "";
+      const ts = new Date(m.mtimeMs).toISOString();
+      return m.description
+        ? `- ${tag}${m.filename} (${ts}): ${m.description}`
+        : `- ${tag}${m.filename} (${ts})`;
+    })
+    .join("\n");
+}

--- a/src/domain/memory/recall.ts
+++ b/src/domain/memory/recall.ts
@@ -1,0 +1,169 @@
+/**
+ * Sonnet-powered memory recall.
+ *
+ * On every user message, scans the local memory/ directory for .md file
+ * headers, sends them + the user query to Sonnet 4.6, and returns the
+ * content of the top 5 most relevant files for injection into context.
+ *
+ * The side-call is cheap: ~500 tokens in, ~50 tokens out per query.
+ *
+ * Adapted from Claude Code's findRelevantMemories.ts blueprint.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { mkdir, readFile } from "fs/promises";
+import * as path from "path";
+import { memoryFreshnessText } from "./memory-age.js";
+import {
+  type MemoryHeader,
+  formatMemoryManifest,
+  scanMemoryFiles,
+} from "./memory-scan.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RelevantMemory {
+  path: string;
+  mtimeMs: number;
+  content: string;
+}
+
+// ---------------------------------------------------------------------------
+// Sonnet client (lazy singleton)
+// ---------------------------------------------------------------------------
+
+let client: Anthropic | null = null;
+
+function getClient(): Anthropic {
+  if (!client) {
+    client = new Anthropic();
+  }
+  return client;
+}
+
+// ---------------------------------------------------------------------------
+// Selector prompt
+// ---------------------------------------------------------------------------
+
+const SELECT_MEMORIES_SYSTEM_PROMPT = `You are selecting memories that will be useful to an AI assistant as it processes a user's query. You will be given the user's query and a list of available memory files with their filenames and descriptions.
+
+Return a JSON object with a "selected_memories" array of filenames for the memories that will clearly be useful (up to 5). Only include memories that you are certain will be helpful based on their name and description.
+- If you are unsure if a memory will be useful, do not include it.
+- If no memories are clearly useful, return an empty array.
+- Be selective and discerning.`;
+
+// ---------------------------------------------------------------------------
+// Memory directory
+// ---------------------------------------------------------------------------
+
+export const LOCAL_MEMORY_DIR = path.join(
+  process.env.HOME || "/Users/christaylor",
+  "Projects/chris-assistant/memory",
+);
+
+/** Ensure the local memory directory exists. Called once on boot. */
+export async function ensureLocalMemoryDir(): Promise<void> {
+  await mkdir(LOCAL_MEMORY_DIR, { recursive: true });
+  console.log("[recall] Local memory dir ready: %s", LOCAL_MEMORY_DIR);
+}
+
+// ---------------------------------------------------------------------------
+// Core API
+// ---------------------------------------------------------------------------
+
+/**
+ * Find memory files relevant to a query by scanning memory file headers
+ * and asking Sonnet to select the most relevant ones.
+ *
+ * Returns up to 5 relevant memories with their content read from disk.
+ * Gracefully returns [] on any failure — never blocks the conversation.
+ */
+export async function findRelevantMemories(
+  query: string,
+  memoryDir: string = LOCAL_MEMORY_DIR,
+): Promise<RelevantMemory[]> {
+  const memories = await scanMemoryFiles(memoryDir);
+  if (memories.length === 0) {
+    return [];
+  }
+
+  const selectedFilenames = await selectRelevantMemories(query, memories);
+  const byFilename = new Map(memories.map((m) => [m.filename, m]));
+
+  const selected = selectedFilenames
+    .map((filename) => byFilename.get(filename))
+    .filter((m): m is MemoryHeader => m !== undefined);
+
+  // Read full content of selected files
+  const results = await Promise.allSettled(
+    selected.map(async (m): Promise<RelevantMemory> => {
+      const content = await readFile(m.filePath, "utf-8");
+      return { path: m.filePath, mtimeMs: m.mtimeMs, content };
+    }),
+  );
+
+  return results
+    .filter(
+      (r): r is PromiseFulfilledResult<RelevantMemory> =>
+        r.status === "fulfilled",
+    )
+    .map((r) => r.value);
+}
+
+/**
+ * Format recalled memories into a context block for prompt injection.
+ * Includes staleness caveats for memories >1 day old.
+ */
+export function formatRecalledMemories(memories: RelevantMemory[]): string {
+  if (memories.length === 0) return "";
+
+  const parts = memories.map((m) => {
+    const filename = path.basename(m.path);
+    const freshness = memoryFreshnessText(m.mtimeMs);
+    const header = freshness
+      ? `### ${filename}\n> ${freshness}\n`
+      : `### ${filename}\n`;
+    return header + m.content;
+  });
+
+  return `# Recalled Memories\n\nThe following memories were selected as relevant to this query.\n\n${parts.join("\n\n---\n\n")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async function selectRelevantMemories(
+  query: string,
+  memories: MemoryHeader[],
+): Promise<string[]> {
+  const validFilenames = new Set(memories.map((m) => m.filename));
+  const manifest = formatMemoryManifest(memories);
+
+  try {
+    const response = await getClient().messages.create({
+      model: "claude-sonnet-4-6-20250514",
+      max_tokens: 256,
+      system: SELECT_MEMORIES_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: `Query: ${query}\n\nAvailable memories:\n${manifest}`,
+        },
+      ],
+    });
+
+    const textBlock = response.content.find((block) => block.type === "text");
+    if (!textBlock || textBlock.type !== "text") {
+      return [];
+    }
+
+    const parsed: { selected_memories: string[] } = JSON.parse(textBlock.text);
+    return parsed.selected_memories.filter((f) => validFilenames.has(f));
+  } catch (e) {
+    console.warn("[recall] selectRelevantMemories failed:", e instanceof Error ? e.message : e);
+    return [];
+  }
+}

--- a/src/domain/memory/repository.ts
+++ b/src/domain/memory/repository.ts
@@ -46,6 +46,23 @@ export async function writeMemoryFile(path: string, content: string, commitMessa
   });
 }
 
+/**
+ * List files in a directory in the memory repo.
+ * Returns relative paths (e.g. "conversations/summaries/2026-03-15.md").
+ */
+export async function listMemoryDir(dirPath: string): Promise<string[]> {
+  try {
+    const response = await octokit.repos.getContent({ owner: repoOwner, repo: repoName, path: dirPath });
+    if (!Array.isArray(response.data)) return [];
+    return response.data
+      .filter((item: any) => item.type === "file")
+      .map((item: any) => item.path as string);
+  } catch (error: any) {
+    if (error.status === 404) return [];
+    throw error;
+  }
+}
+
 export async function appendToMemoryFile(path: string, newContent: string, commitMessage: string): Promise<void> {
   const existing = await readMemoryFile(path);
   const updated = existing ? `${existing.trimEnd()}\n\n${newContent}` : newContent;

--- a/src/domain/memory/update-service.ts
+++ b/src/domain/memory/update-service.ts
@@ -1,5 +1,8 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import * as path from "path";
 import { appendToMemoryFile, writeMemoryFile } from "./repository.js";
 import { MEMORY_CATEGORY_FILES } from "./constants.js";
+import { LOCAL_MEMORY_DIR } from "./recall.js";
 
 const CONTENT_MAX_CHARS = 2000;
 const REPLACE_THROTTLE_MS = 5 * 60 * 1000;
@@ -67,6 +70,82 @@ function validateMemoryContent(args: { category: string; action: "add" | "replac
   return { valid: true };
 }
 
+// ---------------------------------------------------------------------------
+// Category → memory type mapping for local recall files
+// ---------------------------------------------------------------------------
+
+const CATEGORY_TO_TYPE: Record<string, string> = {
+  "about-chris": "user",
+  preferences: "feedback",
+  projects: "project",
+  people: "user",
+  decisions: "project",
+  learnings: "feedback",
+};
+
+/**
+ * Generate a short slug from content for the filename.
+ * Takes first ~40 chars, lowercases, strips non-alphanumeric, joins with dashes.
+ */
+function slugify(text: string): string {
+  return text
+    .slice(0, 60)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .slice(0, 40) || "entry";
+}
+
+/**
+ * Auto-generate a one-line description from content for the frontmatter.
+ * Uses the first line/sentence, capped at 120 chars.
+ */
+function autoDescription(content: string, category: string): string {
+  const firstLine = content.split("\n").find((l) => l.trim().length > 0) || content;
+  // Strip markdown bullets, bold, comment tags
+  const cleaned = firstLine
+    .replace(/^<!--.*?-->\s*/g, "")
+    .replace(/^[-*•]\s*/g, "")
+    .replace(/\*\*/g, "")
+    .trim();
+  const capped = cleaned.length > 120 ? cleaned.slice(0, 117) + "..." : cleaned;
+  return capped || `${category} memory update`;
+}
+
+/**
+ * Dual-write: persist a local topic file in memory/ alongside the GitHub write.
+ * Each update_memory call creates a new file so the recall system has granular
+ * entries to select from. Fire-and-forget — failures are logged but don't block.
+ */
+async function writeLocalMemoryFile(
+  category: string,
+  content: string,
+): Promise<void> {
+  try {
+    await mkdir(LOCAL_MEMORY_DIR, { recursive: true });
+    const type = CATEGORY_TO_TYPE[category] || "reference";
+    const timestamp = new Date().toISOString().split("T")[0];
+    const slug = slugify(content);
+    const filename = `${category}_${timestamp}_${slug}.md`;
+    const filePath = path.join(LOCAL_MEMORY_DIR, filename);
+    const description = autoDescription(content, category);
+
+    const fileContent = `---
+name: ${category} — ${slug.replace(/-/g, " ")}
+description: ${description}
+type: ${type}
+---
+
+${content}
+`;
+    await writeFile(filePath, fileContent, "utf-8");
+    console.log("[memory] Local recall file written: %s", filename);
+  } catch (err: any) {
+    console.warn("[memory] Failed to write local recall file:", err.message);
+  }
+}
+
 export async function executeMemoryTool(args: { category: string; action: "add" | "replace"; content: string }): Promise<string> {
   const validation = validateMemoryContent(args);
   if (!validation.valid) {
@@ -87,6 +166,11 @@ export async function executeMemoryTool(args: { category: string; action: "add" 
     } else {
       await appendToMemoryFile(filePath, entry, `memory: add to ${category}`);
     }
+
+    // Dual-write: also persist as a local topic file for Sonnet recall.
+    // Fire-and-forget — GitHub is the source of truth.
+    writeLocalMemoryFile(category, content).catch(() => {});
+
     return `Memory updated (${category}/${action})`;
   } catch (error: any) {
     return `Failed to update memory: ${error.message}`;

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -20,6 +20,7 @@ import { getSessionId, setSessionId } from "../claude-sessions.js";
 import { formatHistoryForPrompt } from "../conversation.js";
 import type { Provider, ImageAttachment } from "./types.js";
 import { recordUsage } from "../usage-tracker.js";
+import { findRelevantMemories, formatRecalledMemories } from "../domain/memory/recall.js";
 import * as os from "os";
 import * as path from "path";
 
@@ -138,7 +139,26 @@ export function createClaudeProvider(model: string): Provider {
         tools: getCustomMcpTools(),
       });
 
-      const appendPrompt = await getClaudeAppendPrompt();
+      // Fire memory recall + prompt load concurrently — recall is a cheap
+      // Sonnet side-call (~500 tokens in, ~50 out) that selects which local
+      // memory files are relevant to this query.
+      const [appendPromptBase, recalledMemories] = await Promise.all([
+        getClaudeAppendPrompt(),
+        findRelevantMemories(userMessage).catch((e) => {
+          console.warn("[claude] Memory recall failed:", e instanceof Error ? e.message : e);
+          return [];
+        }),
+      ]);
+
+      // Inject recalled memories into the append prompt
+      const recalledSection = formatRecalledMemories(recalledMemories);
+      const appendPrompt = recalledSection
+        ? `${appendPromptBase}\n\n---\n\n${recalledSection}`
+        : appendPromptBase;
+      if (recalledMemories.length > 0) {
+        console.log("[claude] Recalled %d memories for chatId=%d", recalledMemories.length, chatId);
+      }
+
       const thinkingTokens = getThinkingTokens(userMessage);
 
       // Build allowed tools list: custom MCP tools + all native Claude Code tools


### PR DESCRIPTION
## Summary

- **Sonnet recall**: On every user message, scans local memory/ directory for .md files with YAML frontmatter, sends headers + query to Sonnet 4.6 (~500 tokens), gets back top 5 most relevant files, injects their content into conversation context
- **Dual-write**: update_memory and daily summarizer now write to both GitHub (source of truth) and local memory/ (recall index), so new memories are available to Sonnet recall immediately
- **Backfill script**: npx tsx scripts/backfill-local-memory.ts pulls all historical summaries + knowledge from GitHub into local recall files

### New files
- src/domain/memory/recall.ts — orchestrator (findRelevantMemories, formatRecalledMemories)
- src/domain/memory/memory-scan.ts — directory scanner, YAML frontmatter parser
- src/domain/memory/memory-age.ts — staleness detection utilities
- scripts/backfill-local-memory.ts — one-time historical backfill

### Modified files
- src/providers/claude.ts — fires recall concurrently with prompt load, injects results
- src/domain/memory/update-service.ts — dual-write local topic files on every update_memory
- src/domain/conversations/daily-summary-service.ts — dual-write local summary files
- src/domain/memory/repository.ts — added listMemoryDir for backfill
- src/app/service-definitions.ts — ensures memory/ dir exists on boot

## Test plan
- [x] TypeScript typecheck passes
- [x] All 91 tests pass
- [x] esbuild compat check passes
- [ ] Run backfill: npx tsx scripts/backfill-local-memory.ts
- [ ] Restart bot, send message, verify recall fires in logs
- [ ] Verify update_memory creates local files in memory/

Generated with Claude Code