### PR TITLE
feat: emoji reactions on Telegram messages

### DIFF
--- a/src/channels/telegram/handlers.ts
+++ b/src/channels/telegram/handlers.ts
@@ -31,11 +31,21 @@ async function chatWithRetry(
   }
 }
 
+async function reactTo(ctx: Context, emoji: string): Promise<void> {
+  await ctx.api
+    .setMessageReaction(ctx.chat!.id, ctx.message!.message_id, [
+      { type: "emoji", emoji: emoji as any },
+    ])
+    .catch(() => {});
+}
+
 async function handleAiResponse(
   ctx: Context,
   userMessage: string,
   image?: ImageAttachment,
 ): Promise<void> {
+  void reactTo(ctx, "👀");
+
   const sentMsg = await ctx.reply("...");
   const chatId = ctx.chat!.id;
   const messageId = sentMsg.message_id;
@@ -86,11 +96,14 @@ async function handleAiResponse(
         () => ctx.reply(stripMarkdown(chunk)),
       );
     }
+
+    void reactTo(ctx, "✅");
   } catch (error: any) {
     console.error("[telegram] Both chat() attempts failed:", error);
     await ctx.api
       .editMessageText(chatId, messageId, "Something went wrong. Check the logs.")
       .catch(() => {});
+    void reactTo(ctx, "🚫");
   }
 }
 


### PR DESCRIPTION
## Summary
- Reacts 👀 to the user's message immediately on receipt (acknowledgement)
- Reacts ✅ on successful response completion
- Reacts 🚫 on error (❌ is not in Telegram's allowed reaction set)

All reactions are fire-and-forget — failures are silently caught and never affect the response flow.

## Implementation
Single helper `reactTo(ctx, emoji)` added to `handlers.ts`. Reactions target the user's incoming message (`ctx.message.message_id`), which is the natural Telegram UX.

## Test plan
- [ ] Send a message — 👀 should appear immediately
- [ ] Wait for response to complete — 👀 should be replaced by ✅
- [ ] Trigger an error (e.g. kill API key temporarily) — 🚫 should appear

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)