### PR TITLE
fix: survive Telegram getUpdates 409 instead of crashing

### DIFF
--- a/src/channels/telegram/index.ts
+++ b/src/channels/telegram/index.ts
@@ -1,3 +1,4 @@
+import { GrammyError } from "grammy";
 import { bot } from "./bot.js";
 import { TELEGRAM_COMMAND_MENU, registerTelegramCommands } from "./commands.js";
 import { registerTelegramMessageHandlers } from "./handlers.js";
@@ -11,8 +12,30 @@ export async function setTelegramCommandMenu(): Promise<void> {
   await bot.api.setMyCommands([...TELEGRAM_COMMAND_MENU]);
 }
 
+// Retry on 409 instead of crashing — another poller occasionally steals the
+// slot, Telegram's 30s long-poll needs to expire before we can reclaim it.
+const POLL_CONFLICT_BACKOFF_MS = 35_000;
+
 export function startTelegram(onStart: (botInfo: any) => void): void {
-  bot.start({ onStart });
+  const run = async (): Promise<void> => {
+    try {
+      await bot.start({ onStart });
+    } catch (err) {
+      if (err instanceof GrammyError && err.error_code === 409) {
+        console.warn(
+          `[telegram] getUpdates 409 — another poller is active; retrying in ${POLL_CONFLICT_BACKOFF_MS / 1000}s`,
+        );
+        setTimeout(() => { void run(); }, POLL_CONFLICT_BACKOFF_MS);
+        return;
+      }
+      throw err;
+    }
+  };
+
+  void run().catch((err: any) => {
+    console.error("[telegram] fatal polling error:", err?.message ?? err);
+    process.exit(1);
+  });
 }
 
 export function stopTelegram(): void {

--- a/src/channels/telegram/index.ts
+++ b/src/channels/telegram/index.ts
@@ -17,25 +17,36 @@ export async function setTelegramCommandMenu(): Promise<void> {
 const POLL_CONFLICT_BACKOFF_MS = 35_000;
 
 export function startTelegram(onStart: (botInfo: any) => void): void {
+  // Downstream services (health monitor, timers, alert on startup) are not
+  // all idempotent, so only fire onStart for the first successful poll.
+  let onStartFired = false;
+  const fireOnStartOnce = (info: Parameters<typeof onStart>[0]): void => {
+    if (onStartFired) return;
+    onStartFired = true;
+    onStart(info);
+  };
+
+  const onFatal = (err: any): void => {
+    console.error("[telegram] fatal polling error:", err?.message ?? err);
+    process.exit(1);
+  };
+
   const run = async (): Promise<void> => {
     try {
-      await bot.start({ onStart });
+      await bot.start({ onStart: fireOnStartOnce });
     } catch (err) {
       if (err instanceof GrammyError && err.error_code === 409) {
         console.warn(
           `[telegram] getUpdates 409 — another poller is active; retrying in ${POLL_CONFLICT_BACKOFF_MS / 1000}s`,
         );
-        setTimeout(() => { void run(); }, POLL_CONFLICT_BACKOFF_MS);
+        setTimeout(() => { run().catch(onFatal); }, POLL_CONFLICT_BACKOFF_MS);
         return;
       }
       throw err;
     }
   };
 
-  void run().catch((err: any) => {
-    console.error("[telegram] fatal polling error:", err?.message ?? err);
-    process.exit(1);
-  });
+  run().catch(onFatal);
 }
 
 export function stopTelegram(): void {


### PR DESCRIPTION
## Summary

- Catch `GrammyError` with `error_code === 409` in `startTelegram` and retry `bot.start()` after a 35s backoff (one Telegram long-poll cycle) instead of crashing the process.
- Non-409 errors still propagate and exit — preserves existing behavior for config / auth / network failures.

## Why

From 2026-04-19 incident (#92): an external, intermittent rogue poller was holding `@jarvis_allknowing_bot`'s `getUpdates` slot. A single 409 crashed chris-assistant, pm2 restarted within seconds, the new instance hit the same 409, and each restart sent a Telegram startup notification — creating an unusable notification storm.

With this patch, a 409 causes a single `[telegram] getUpdates 409 — another poller is active; retrying in 35s` log line and the process stays alive. Validated in production on 2026-04-19 09:56:30: real 409 caught, process survived, poll reclaimed at 09:57:05.

## Known side-effect

Each retry re-fires the `onStart` callback, which re-enters `postTelegramRegistry.startAll()`. The registered services guard against double-start and emit harmless `[service] Already running, ignoring duplicate start` lines. Cosmetic; tracked for follow-up in #92.

## Test plan

- [x] `npm run typecheck` passes
- [x] Validated in production on 2026-04-19 — rogue 409 hit, process survived, poll reclaimed, uptime continued climbing
- [ ] If the rogue poller returns, confirm the retry log line appears without a pm2 restart

Closes part of #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)