### PR TITLE
feat: dashboard webchat with cross-channel live mirror

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -23,6 +23,15 @@ http://localhost:3100
 
 Bot uptime, active model and provider, image model, pm2 process info, and health check indicators (GitHub, Telegram, token expiry).
 
+### Chat
+
+A browser-based chat UI backed by the same conversation thread used by Telegram. Messages sent from the dashboard, replies produced by the assistant, and messages that arrive via Telegram all land in one shared history (keyed by `TELEGRAM_ALLOWED_USER_ID`) and mirror live across every open surface.
+
+- Composer supports Enter to send, Shift+Enter for newline. The Send button becomes Stop mid-generation and cancels the in-flight response (server-side abort triggers on client disconnect).
+- Replies stream in token-by-token via SSE.
+- A live/reconnecting/offline indicator reports the state of the cross-channel mirror stream. On drop the client auto-reconnects with backoff and re-hydrates the thread so no messages are missed.
+- Each message carries a source badge (`web`, `telegram`, `discord`, `scheduled`) so it is clear which channel a turn originated from when switching mid-conversation.
+
 ### Schedules
 
 Lists all cron-scheduled tasks with their expression, prompt, enabled state, and next-run info. Supports editing, toggling, and deleting schedules directly from the UI.
@@ -60,6 +69,8 @@ All endpoints return JSON and support CORS.
 | `PUT` | `/api/schedules/:id` | Update a schedule |
 | `DELETE` | `/api/schedules/:id` | Delete a schedule |
 | `GET` | `/api/conversation` | Current conversation history |
+| `GET` | `/api/conversation/stream` | SSE stream of new messages across all channels (live mirror) |
+| `POST` | `/api/chat` | Send a chat message; replies stream back as SSE (`chunk` / `done` / `error`) |
 | `GET` | `/api/archives` | List archive dates |
 | `GET` | `/api/archives/:date` | Read archive for a date |
 | `GET` | `/api/archives/:date/summary` | Read AI summary for a date |

--- a/docs/development/gotchas.md
+++ b/docs/development/gotchas.md
@@ -19,6 +19,36 @@ const re = new RegExp("<" + "/think>", "g")
 
 The `npm run typecheck` command includes an automated check (`scripts/check-esbuild-compat.js`) that catches this.
 
+## Escape Sequences in Inline Dashboard JS
+
+The dashboard HTML in `src/dashboard/ui.ts` is built from a TypeScript template literal (`` ` ... ` ``). Inline `<script>` contents live inside that template, so every `\n`, `\t`, `\\` etc. inside the inline JS is consumed by TypeScript before the string is served — a `"\n"` in the source becomes a real newline embedded in the quoted JS string, which blows up parsing in the browser.
+
+```typescript
+// BAD — TS eats the \n; the browser sees an unterminated string.
+return `<script>
+  while ((idx = buf.indexOf("\n\n")) !== -1) { ... }
+</script>`
+
+// GOOD — double the backslashes so the served JS gets "\n\n".
+return `<script>
+  while ((idx = buf.indexOf("\\n\\n")) !== -1) { ... }
+</script>`
+```
+
+Symptom: the dashboard loads blank, all skeletons shimmer forever, the "loading..." badge never resolves — because a `SyntaxError` at page parse kills every inline handler (not just the new code). When touching inline script in `ui.ts`, any JS-level escape sequence needs its backslash doubled.
+
+Quick check before restarting the bot:
+
+```bash
+npx tsx -e "
+import { getDashboardHtml } from './src/dashboard/ui.ts';
+import vm from 'node:vm';
+const m = getDashboardHtml().match(/<script>([\s\S]*?)<\/script>/);
+try { new vm.Script(m[1]); console.log('OK'); }
+catch(e) { console.log('ERR:', e.message); }
+"
+```
+
 ## pm2 PATH Isolation
 
 pm2 spawns processes in its own daemon. It doesn't inherit your shell PATH. That's why `pm2-helper.ts` exports `TSX_BIN` as an absolute path to `node_modules/.bin/tsx`.

--- a/src/channels/web/handlers.ts
+++ b/src/channels/web/handlers.ts
@@ -1,0 +1,46 @@
+import { addMessage } from "../../conversation.js";
+import { chatService } from "../../agent/chat-service.js";
+import { config } from "../../config.js";
+import type { ImageAttachment } from "../../providers/types.js";
+
+export interface HandleWebMessageOptions {
+  text: string;
+  images?: ImageAttachment[];
+  onChunk: (accumulated: string) => void;
+  signal: AbortSignal;
+}
+
+export async function handleWebMessage(opts: HandleWebMessageOptions): Promise<void> {
+  const chatId = config.telegram.allowedUserId;
+  const meta = { source: "web" as const };
+
+  const onAbort = () => {
+    chatService.abort(chatId);
+  };
+  opts.signal.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    await addMessage(chatId, "user", opts.text, meta);
+    const reply = await chatService.sendMessage({
+      chatId,
+      userMessage: opts.text,
+      onChunk: opts.onChunk,
+      images: opts.images,
+    });
+    await addMessage(chatId, "assistant", reply, meta);
+  } finally {
+    opts.signal.removeEventListener("abort", onAbort);
+  }
+}
+
+export function parseDataUrlImages(raw: unknown): ImageAttachment[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const out: ImageAttachment[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    const match = entry.match(/^data:([^;]+);base64,(.+)$/);
+    if (!match) continue;
+    out.push({ mimeType: match[1]!, base64: match[2]! });
+  }
+  return out.length > 0 ? out : undefined;
+}

--- a/src/dashboard/runtime.ts
+++ b/src/dashboard/runtime.ts
@@ -9,6 +9,8 @@ import { listLocalArchiveDates, readLocalArchive } from "../conversation-archive
 import { listLocalJournalDates, readLocalJournal } from "../memory/journal.js";
 import { readMemoryFile, writeMemoryFile } from "../memory/github.js";
 import { getHistory } from "../conversation.js";
+import { conversationEvents, type ConversationEvent } from "../domain/conversations/events.js";
+import { handleWebMessage, parseDataUrlImages } from "../channels/web/handlers.js";
 import { getBotProcess } from "../cli/pm2-helper.js";
 import { loadSkillIndex, loadSkill } from "../skills/loader.js";
 import { LIMITS } from "../infra/config/limits.js";
@@ -294,6 +296,67 @@ async function handleConversationHistory(res: ServerResponse): Promise<void> {
   json(res, { messages: await getHistory(config.telegram.allowedUserId) });
 }
 
+function sseHeaders(res: ServerResponse): void {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+}
+
+function handleConversationStream(req: IncomingMessage, res: ServerResponse): void {
+  sseHeaders(res);
+  res.write(`: connected\n\n`);
+
+  const userId = config.telegram.allowedUserId;
+  const handler = (event: ConversationEvent) => {
+    if (event.chatId !== userId) return;
+    res.write(`event: message\ndata: ${JSON.stringify(event)}\n\n`);
+  };
+
+  conversationEvents.on("message", handler);
+  req.on("close", () => {
+    conversationEvents.off("message", handler);
+  });
+}
+
+async function handleChatPost(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  let body: any;
+  try {
+    body = JSON.parse(await readBody(req));
+  } catch {
+    json(res, { error: "Invalid JSON" }, 400);
+    return;
+  }
+
+  const text = typeof body?.text === "string" ? body.text.trim() : "";
+  if (!text) {
+    json(res, { error: "text is required" }, 400);
+    return;
+  }
+  const images = parseDataUrlImages(body?.images);
+
+  sseHeaders(res);
+  res.write(`: open\n\n`);
+
+  const ac = new AbortController();
+  req.on("close", () => ac.abort());
+
+  const onChunk = (accumulated: string) => {
+    res.write(`event: chunk\ndata: ${JSON.stringify({ text: accumulated })}\n\n`);
+  };
+
+  try {
+    await handleWebMessage({ text, images, onChunk, signal: ac.signal });
+    res.write(`event: done\ndata: {}\n\n`);
+  } catch (err: any) {
+    const message = err?.message ?? String(err);
+    res.write(`event: error\ndata: ${JSON.stringify({ message })}\n\n`);
+  } finally {
+    res.end();
+  }
+}
+
 async function handleSkills(res: ServerResponse): Promise<void> {
   try {
     const index = await loadSkillIndex();
@@ -311,7 +374,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, getHtml:
   if (req.method === "OPTIONS") {
     const allowedOrigin = getAllowedOrigin(req);
     const headers: Record<string, string> = {
-      "Access-Control-Allow-Methods": "GET, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
       "Access-Control-Allow-Headers": "Authorization, Content-Type",
     };
     if (allowedOrigin) headers["Access-Control-Allow-Origin"] = allowedOrigin;
@@ -343,6 +406,8 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, getHtml:
     if (req.method === "DELETE" && scheduleIdMatch) return handleScheduleDelete(res, scheduleIdMatch[1]);
 
     if (req.method === "GET" && pathname === "/api/conversation") return await handleConversationHistory(res);
+    if (req.method === "GET" && pathname === "/api/conversation/stream") return handleConversationStream(req, res);
+    if (req.method === "POST" && pathname === "/api/chat") return await handleChatPost(req, res);
     if (req.method === "GET" && pathname === "/api/archives") return handleArchives(res);
 
     const archiveDateMatch = pathname.match(/^\/api\/archives\/(\d{4}-\d{2}-\d{2})$/);

--- a/src/dashboard/ui.ts
+++ b/src/dashboard/ui.ts
@@ -212,6 +212,39 @@ tr.clickable:hover { background: var(--bg3); }
 .cal-legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text2); }
 .cal-legend-swatch { width: 12px; height: 12px; border-radius: 3px; }
 .flex-between { display: flex; justify-content: space-between; align-items: center; }
+
+/* Chat */
+#sec-chat .card { padding: 0; overflow: hidden; }
+.chat-header { display: flex; align-items: center; gap: 10px; padding: 12px 16px; border-bottom: 1px solid var(--border); background: var(--bg2); }
+.chat-header h3 { font-size: 13px; font-weight: 600; color: var(--text2); text-transform: uppercase; letter-spacing: 0.5px; margin: 0; }
+.chat-header .chat-status { margin-left: auto; display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text2); }
+.chat-header .live-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text2); transition: background 0.2s; }
+.chat-header .live-dot.live { background: var(--green); box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.6); animation: livePulse 2s infinite; }
+.chat-header .live-dot.reconnecting { background: var(--yellow); animation: none; }
+@keyframes livePulse { 0% { box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.5); } 70% { box-shadow: 0 0 0 6px rgba(74, 222, 128, 0); } 100% { box-shadow: 0 0 0 0 rgba(74, 222, 128, 0); } }
+.chat-thread { display: flex; flex-direction: column; gap: 8px; padding: 16px; height: 60vh; min-height: 420px; overflow-y: auto; background: var(--bg); }
+.chat-thread.empty { align-items: center; justify-content: center; }
+.chat-row { display: flex; flex-direction: column; max-width: 85%; }
+.chat-row.user { align-self: flex-end; align-items: flex-end; }
+.chat-row.assistant { align-self: flex-start; align-items: flex-start; }
+.chat-bubble { padding: 10px 14px; border-radius: 12px; font-size: 14px; line-height: 1.55; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: anywhere; }
+.chat-row.user .chat-bubble { background: var(--accent); color: #fff; border-bottom-right-radius: 4px; }
+.chat-row.assistant .chat-bubble { background: var(--bg2); color: var(--text); border: 1px solid var(--border); border-bottom-left-radius: 4px; }
+.chat-meta { display: flex; gap: 6px; align-items: center; font-size: 11px; color: var(--text2); margin: 3px 4px 0; }
+.chat-source { padding: 1px 7px; border-radius: 10px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.4px; background: var(--bg3); color: var(--text2); }
+.chat-source.web { background: rgba(108, 138, 255, 0.18); color: var(--accent); }
+.chat-source.telegram { background: rgba(34, 211, 238, 0.18); color: #5ee0f0; }
+.chat-source.discord { background: rgba(192, 132, 252, 0.18); color: #d0a4fd; }
+.chat-source.scheduled { background: rgba(251, 191, 36, 0.18); color: var(--yellow); }
+.chat-cursor { display: inline-block; width: 7px; height: 14px; margin-left: 2px; background: currentColor; vertical-align: text-bottom; animation: chatBlink 1s step-end infinite; }
+@keyframes chatBlink { 50% { opacity: 0; } }
+.chat-composer { display: flex; gap: 8px; padding: 12px; border-top: 1px solid var(--border); background: var(--bg2); align-items: flex-end; }
+.chat-input { flex: 1; background: var(--bg); border: 1px solid var(--border); border-radius: 10px; color: var(--text); font-family: var(--font); font-size: 14px; padding: 10px 12px; resize: none; min-height: 40px; max-height: 200px; line-height: 1.5; }
+.chat-input:focus { outline: none; border-color: var(--accent); }
+.chat-send { background: var(--accent); color: #fff; border: none; padding: 10px 18px; border-radius: 10px; cursor: pointer; font-size: 14px; font-family: var(--font); font-weight: 500; }
+.chat-send:disabled { opacity: 0.5; cursor: not-allowed; }
+.chat-send.stop { background: var(--red); }
+.chat-thread .empty-state { margin: auto; }
 </style>
 </head>
 <body>
@@ -225,6 +258,7 @@ tr.clickable:hover { background: var(--bg3); }
 
   <div class="tabs">
     <button class="tab active" data-tab="status">Status</button>
+    <button class="tab" data-tab="chat">Chat</button>
     <button class="tab" data-tab="schedules">Schedules</button>
     <button class="tab" data-tab="conversations">Conversations</button>
     <button class="tab" data-tab="memory">Memory</button>
@@ -246,6 +280,26 @@ tr.clickable:hover { background: var(--bg3); }
     <div class="card">
       <h3>Health Checks</h3>
       <div id="health-checks"><div><div class="skeleton skeleton-row"></div><div class="skeleton skeleton-row short"></div><div class="skeleton skeleton-row medium"></div></div></div>
+    </div>
+  </div>
+
+  <!-- Chat -->
+  <div class="section" id="sec-chat">
+    <div class="card">
+      <div class="chat-header">
+        <h3>Live Chat</h3>
+        <div class="chat-status">
+          <span class="live-dot" id="chat-live-dot"></span>
+          <span id="chat-live-label">connecting</span>
+        </div>
+      </div>
+      <div class="chat-thread empty" id="chat-thread">
+        <div class="empty-state"><div class="empty-state-icon">💬</div><div class="empty-state-heading">Loading thread</div><div class="empty-state-description">Hydrating shared history with Telegram</div></div>
+      </div>
+      <div class="chat-composer">
+        <textarea class="chat-input" id="chat-input" rows="1" placeholder="Message Chris Assistant..."></textarea>
+        <button class="chat-send" id="chat-send">Send</button>
+      </div>
     </div>
   </div>
 
@@ -456,6 +510,7 @@ tabs.forEach(t => t.addEventListener("click", () => {
 
 function activateTab(tab) {
   if (tab === "status") loadStatus();
+  if (tab === "chat") startChat();
   if (tab === "schedules") loadSchedules();
   if (tab === "conversations") loadArchiveDates();
   if (tab === "memory") loadMemoryFiles();
@@ -1013,6 +1068,326 @@ document.querySelectorAll("#log-mode button").forEach(function(btn) {
     if (activeTab === "logs") startLogStream();
   });
 });
+
+// --- Chat ---
+var chatStarted = false;
+var chatStreamController = null;
+var chatSendController = null;
+var chatSeen = new Set();
+var chatReconnectTimer = null;
+var chatStreamBackoff = 1000;
+var chatPendingAssistantRow = null;
+var chatPendingUserRow = null;
+
+function chatUpdateRowTimestamp(row, ts) {
+  if (!row || !row.row) return;
+  var timeEl = row.row.querySelector(".chat-meta span:first-child");
+  if (timeEl && ts) timeEl.textContent = new Date(ts).toLocaleTimeString();
+}
+
+function chatSetLive(state) {
+  var dot = document.getElementById("chat-live-dot");
+  var label = document.getElementById("chat-live-label");
+  if (!dot || !label) return;
+  dot.classList.remove("live", "reconnecting");
+  if (state === "live") { dot.classList.add("live"); label.textContent = "live"; }
+  else if (state === "reconnecting") { dot.classList.add("reconnecting"); label.textContent = "reconnecting"; }
+  else { label.textContent = "offline"; }
+}
+
+function chatSourceLabel(source) {
+  if (!source) return "";
+  return source;
+}
+
+function chatRenderMessage(msg, opts) {
+  opts = opts || {};
+  var thread = document.getElementById("chat-thread");
+  if (!thread) return null;
+  if (thread.classList.contains("empty")) {
+    thread.classList.remove("empty");
+    thread.innerHTML = "";
+  }
+
+  var row = document.createElement("div");
+  row.className = "chat-row " + msg.role;
+
+  var bubble = document.createElement("div");
+  bubble.className = "chat-bubble";
+  bubble.textContent = msg.content || "";
+  row.appendChild(bubble);
+
+  var meta = document.createElement("div");
+  meta.className = "chat-meta";
+  var time = msg.timestamp ? new Date(msg.timestamp).toLocaleTimeString() : "";
+  var timeEl = document.createElement("span");
+  timeEl.textContent = time;
+  meta.appendChild(timeEl);
+  var source = msg.meta && msg.meta.source ? msg.meta.source : null;
+  if (source) {
+    var badge = document.createElement("span");
+    badge.className = "chat-source " + source;
+    badge.textContent = chatSourceLabel(source);
+    meta.appendChild(badge);
+  }
+  row.appendChild(meta);
+
+  thread.appendChild(row);
+  if (!opts.noScroll) chatScrollToBottom();
+  return { row: row, bubble: bubble };
+}
+
+function chatScrollToBottom() {
+  var thread = document.getElementById("chat-thread");
+  if (thread) thread.scrollTop = thread.scrollHeight;
+}
+
+function chatKey(msg) {
+  var ts = msg.timestamp || 0;
+  return ts + "|" + msg.role;
+}
+
+function chatAppendIfNew(msg) {
+  var key = chatKey(msg);
+  if (chatSeen.has(key)) return false;
+  chatSeen.add(key);
+
+  if (msg.role === "user" && chatPendingUserRow) {
+    chatUpdateRowTimestamp(chatPendingUserRow, msg.timestamp);
+    chatPendingUserRow = null;
+    return false;
+  }
+  if (msg.role === "assistant" && chatPendingAssistantRow) {
+    var pending = chatPendingAssistantRow;
+    if (pending.bubble) pending.bubble.textContent = msg.content || "";
+    chatUpdateRowTimestamp(pending, msg.timestamp);
+    chatPendingAssistantRow = null;
+    chatScrollToBottom();
+    return false;
+  }
+
+  chatRenderMessage(msg);
+  return true;
+}
+
+async function chatHydrate() {
+  try {
+    var data = await api("/api/conversation");
+    var thread = document.getElementById("chat-thread");
+    if (!thread) return;
+    thread.classList.remove("empty");
+    thread.innerHTML = "";
+    chatSeen = new Set();
+    var msgs = data.messages || [];
+    for (var i = 0; i < msgs.length; i++) {
+      var m = msgs[i];
+      chatSeen.add(chatKey(m));
+      chatRenderMessage(m, { noScroll: true });
+    }
+    if (msgs.length === 0) {
+      thread.classList.add("empty");
+      thread.innerHTML = '<div class="empty-state"><div class="empty-state-icon">💬</div><div class="empty-state-heading">No messages yet</div><div class="empty-state-description">Say hello — Telegram and this tab share the same thread</div></div>';
+    }
+    chatScrollToBottom();
+  } catch (e) {
+    showToast("Failed to load history: " + e.message, "error");
+  }
+}
+
+async function chatConsumeSse(response, onEvent) {
+  var reader = response.body.getReader();
+  var decoder = new TextDecoder();
+  var buf = "";
+  while (true) {
+    var chunk = await reader.read();
+    if (chunk.done) break;
+    buf += decoder.decode(chunk.value, { stream: true });
+    var idx;
+    while ((idx = buf.indexOf("\\n\\n")) !== -1) {
+      var frame = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      var lines = frame.split("\\n");
+      var eventName = "message";
+      var dataLines = [];
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        if (line.startsWith(":")) continue;
+        if (line.startsWith("event:")) eventName = line.slice(6).trim();
+        else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+      }
+      if (dataLines.length === 0) continue;
+      var dataStr = dataLines.join("\\n");
+      var parsed = null;
+      try { parsed = JSON.parse(dataStr); } catch (_) {}
+      onEvent(eventName, parsed, dataStr);
+    }
+  }
+}
+
+async function chatOpenStream() {
+  if (chatStreamController) {
+    try { chatStreamController.abort(); } catch (_) {}
+  }
+  var ctrl = new AbortController();
+  chatStreamController = ctrl;
+  chatSetLive("reconnecting");
+
+  try {
+    var res = await fetch("/api/conversation/stream", {
+      headers: authHeaders(),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) throw new Error("stream " + res.status);
+    chatSetLive("live");
+    chatStreamBackoff = 1000;
+
+    await chatConsumeSse(res, function(eventName, data) {
+      if (eventName === "message" && data) {
+        chatAppendIfNew(data);
+      }
+    });
+    // Stream ended cleanly
+    if (chatStreamController === ctrl) chatScheduleReconnect();
+  } catch (e) {
+    if (ctrl.signal.aborted) return;
+    if (chatStreamController === ctrl) chatScheduleReconnect();
+  }
+}
+
+function chatScheduleReconnect() {
+  chatSetLive("reconnecting");
+  if (chatReconnectTimer) clearTimeout(chatReconnectTimer);
+  var delay = Math.min(chatStreamBackoff, 15000);
+  chatStreamBackoff = Math.min(chatStreamBackoff * 2, 15000);
+  chatReconnectTimer = setTimeout(function() {
+    chatReconnectTimer = null;
+    chatHydrate().finally(chatOpenStream);
+  }, delay);
+}
+
+function chatSetSending(sending) {
+  var btn = document.getElementById("chat-send");
+  var input = document.getElementById("chat-input");
+  if (!btn || !input) return;
+  if (sending) {
+    btn.textContent = "Stop";
+    btn.classList.add("stop");
+    input.disabled = false;
+  } else {
+    btn.textContent = "Send";
+    btn.classList.remove("stop");
+    input.disabled = false;
+    btn.disabled = false;
+  }
+}
+
+async function chatSend() {
+  var input = document.getElementById("chat-input");
+  if (!input) return;
+  var text = input.value.trim();
+  if (!text) return;
+
+  input.value = "";
+  chatAutoResize(input);
+
+  var ctrl = new AbortController();
+  chatSendController = ctrl;
+  chatSetSending(true);
+
+  var now = Date.now();
+  chatPendingUserRow = chatRenderMessage({
+    role: "user",
+    content: text,
+    timestamp: now,
+    meta: { source: "web" },
+  });
+  chatPendingAssistantRow = chatRenderMessage({
+    role: "assistant",
+    content: "",
+    timestamp: now,
+    meta: { source: "web" },
+  });
+  var bubble = chatPendingAssistantRow ? chatPendingAssistantRow.bubble : null;
+  if (bubble) bubble.innerHTML = '<span class="chat-cursor"></span>';
+
+  try {
+    var res = await fetch("/api/chat", {
+      method: "POST",
+      headers: Object.assign({ "Content-Type": "application/json" }, authHeaders()),
+      body: JSON.stringify({ text: text }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) throw new Error("chat " + res.status);
+
+    await chatConsumeSse(res, function(eventName, data) {
+      if (eventName === "chunk" && data && typeof data.text === "string") {
+        if (bubble) {
+          bubble.textContent = data.text;
+          var cursor = document.createElement("span");
+          cursor.className = "chat-cursor";
+          bubble.appendChild(cursor);
+          chatScrollToBottom();
+        }
+      } else if (eventName === "error" && data) {
+        if (bubble) bubble.textContent = "⚠️ " + (data.message || "error");
+      }
+      // on "done" the stream mirror will deliver the final authoritative turn;
+      // the placeholder stays visible until then.
+    });
+  } catch (e) {
+    if (!ctrl.signal.aborted && bubble) {
+      bubble.textContent = "⚠️ " + e.message;
+    }
+  } finally {
+    if (bubble) {
+      var cursor = bubble.querySelector(".chat-cursor");
+      if (cursor) cursor.remove();
+    }
+    chatSendController = null;
+    chatSetSending(false);
+  }
+}
+
+function chatStop() {
+  if (chatSendController) {
+    try { chatSendController.abort(); } catch (_) {}
+  }
+}
+
+function chatAutoResize(el) {
+  el.style.height = "auto";
+  el.style.height = Math.min(el.scrollHeight, 200) + "px";
+}
+
+function startChat() {
+  if (chatStarted) {
+    chatScrollToBottom();
+    return;
+  }
+  chatStarted = true;
+
+  var input = document.getElementById("chat-input");
+  var sendBtn = document.getElementById("chat-send");
+
+  if (input) {
+    input.addEventListener("input", function() { chatAutoResize(input); });
+    input.addEventListener("keydown", function(e) {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        if (chatSendController) chatStop();
+        else chatSend();
+      }
+    });
+  }
+  if (sendBtn) {
+    sendBtn.addEventListener("click", function() {
+      if (chatSendController) chatStop();
+      else chatSend();
+    });
+  }
+
+  chatHydrate().finally(chatOpenStream);
+}
 
 // --- Utilities ---
 function esc(s) {

--- a/src/domain/conversations/events.ts
+++ b/src/domain/conversations/events.ts
@@ -1,0 +1,13 @@
+import { EventEmitter } from "node:events";
+import type { ConversationMeta } from "./types.js";
+
+export interface ConversationEvent {
+  chatId: number;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: number;
+  meta?: ConversationMeta;
+}
+
+export const conversationEvents = new EventEmitter();
+conversationEvents.setMaxListeners(50);

--- a/src/domain/conversations/history-service.ts
+++ b/src/domain/conversations/history-service.ts
@@ -1,4 +1,5 @@
 import { archiveMessage } from "./archive-service.js";
+import { conversationEvents } from "./events.js";
 import { ensureConversationStoreLoaded, saveConversationStore } from "./store.js";
 import type { ConversationMessage, ConversationMeta } from "./types.js";
 import { tryDream } from "../memory/dream-service.js";
@@ -31,6 +32,7 @@ export async function addMessage(
   const now = Date.now();
   history.push({ role, content, timestamp: now });
   archiveMessage(chatId, role, content, now, meta);
+  conversationEvents.emit("message", { chatId, role, content, timestamp: now, meta });
 
   if (history.length > MAX_HISTORY) {
     history.splice(0, history.length - MAX_HISTORY);

--- a/src/domain/conversations/types.ts
+++ b/src/domain/conversations/types.ts
@@ -5,7 +5,7 @@ export interface ConversationMessage {
 }
 
 export interface ConversationMeta {
-  source?: "telegram" | "discord" | "scheduled";
+  source?: "telegram" | "discord" | "scheduled" | "web";
   channelName?: string;
 }
 
@@ -14,6 +14,6 @@ export interface ArchiveEntry {
   chatId: number;
   role: "user" | "assistant";
   content: string;
-  source?: "telegram" | "discord" | "scheduled";
+  source?: "telegram" | "discord" | "scheduled" | "web";
   channelName?: string;
 }


### PR DESCRIPTION
## Summary
- Adds a **Chat** tab to the mission control dashboard — you can talk to the assistant from the browser without being on Telegram.
- **Single unified thread across channels**: webchat uses `TELEGRAM_ALLOWED_USER_ID` as its `chatId`, so Telegram and the dashboard share one conversation. Every turn is tagged with `source: web | telegram | discord | scheduled`.
- **Live cross-channel mirror**: a new `conversationEvents` EventEmitter fires on every `addMessage()`. The dashboard subscribes via `GET /api/conversation/stream` (SSE) so a Telegram reply appears in an open browser tab in real time, and vice versa.

## What's new

**Backend**
- `src/domain/conversations/events.ts` — singleton pub/sub for every conversation write.
- `src/channels/web/handlers.ts` — `handleWebMessage({ text, images?, onChunk, signal })`. Client disconnect aborts the in-flight generation via `chatService.abort()`.
- `src/dashboard/runtime.ts` — `POST /api/chat` (SSE: `chunk`/`done`/`error`) and `GET /api/conversation/stream` (SSE live mirror). Both reuse existing Bearer/localhost auth + CORS.

**Frontend** (`src/dashboard/ui.ts`)
- Chat tab: chat bubbles (user right, assistant left), auto-growing composer, Enter to send / Shift+Enter newline, Send ↔ Stop toggle.
- Optimistic user + assistant rendering; the mirror stream adopts the placeholder with the authoritative content so ordering is always `you → reply` and there are no duplicates.
- Live / reconnecting / offline indicator; auto-reconnect with 1s→15s backoff and re-hydrate on reconnect.
- Source badges per message.

**Docs**
- `docs/dashboard.md` — new tab + endpoints documented.
- `docs/development/gotchas.md` — writes up the TS-template-literal escape trap for inline dashboard JS (backslashes must be doubled) and a one-liner to verify the inline script parses before restarting the bot.

## Notes
- No provider changes, no schema changes, no migrations.
- `conversations.json` already keyed by numeric `chatId`; webchat shares the Telegram one.
- Browser accepts `data:<mime>;base64,<b64>` URLs in `images[]`; UI-side upload is deferred to a follow-up (tracked in the Dashboard Webchat linear project).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 185/185 passing
- [x] Inline dashboard `<script>` parses cleanly (verified with `new vm.Script`)
- [x] Local browser smoke test: send from web, get streamed reply; send from Telegram with web tab open, message mirrors into the dashboard instantly
- [ ] Reviewer: sanity-check the optimistic adoption in `chatAppendIfNew` (ordering + no-duplicate) under rapid back-to-back sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)