### PR TITLE
feat(doctor): guard ~/.pm2/dump.pm2 perms and warn on plaintext secrets (#95)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, chmodSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { execFileSync } from "child_process";
@@ -274,6 +274,40 @@ export function registerDoctorCommand(program: Command) {
             return proc.status === "errored" ? "fail" : "warn";
           },
         },
+        {
+          // pm2 save snapshots the runtime env of running processes — including
+          // secrets loaded by dotenv at startup, not just vars explicitly passed
+          // to pm2 start. Anyone with read access to dump.pm2 (default mode 0644)
+          // can read those secrets.
+          name: "pm2 dump file (~/.pm2/dump.pm2) hygiene",
+          run: async () => {
+            const dumpPath = resolve(process.env.HOME || "~", ".pm2/dump.pm2");
+            if (!existsSync(dumpPath)) {
+              return "pass";
+            }
+            try {
+              const contents = readFileSync(dumpPath, "utf-8");
+              const secretPattern = /TOKEN|KEY|SECRET|AUTH|SESSION|WEBHOOK/i;
+              if (secretPattern.test(contents)) {
+                console.log(
+                  "    %s may contain plaintext secrets (dotenv-loaded env vars are snapshotted by `pm2 save`).",
+                  dumpPath,
+                );
+                console.log(
+                  "    Recommend rotating affected secrets, then re-running `pm2 save` after secret hygiene.",
+                );
+                console.log(
+                  "    Run `chris doctor --fix` to chmod 600 the dump file.",
+                );
+                return "warn";
+              }
+              return "pass";
+            } catch (err: any) {
+              console.log("    Could not read dump file: %s", err.message);
+              return "warn";
+            }
+          },
+        },
       ];
 
       let passes = 0;
@@ -294,6 +328,19 @@ export function registerDoctorCommand(program: Command) {
       // --fix: attempt to diagnose and repair
       if (opts.fix) {
         console.log("\n--- Auto-fix ---\n");
+
+        // Tighten perms on ~/.pm2/dump.pm2 if present. Idempotent — safe to run
+        // every --fix invocation. See note on the dump.pm2 check above for why
+        // this matters (pm2 save snapshots dotenv-loaded secrets at mode 0644).
+        try {
+          const dumpPath = resolve(process.env.HOME || "~", ".pm2/dump.pm2");
+          if (existsSync(dumpPath)) {
+            chmodSync(dumpPath, 0o600);
+            console.log("  %s Set %s to mode 0600", PASS, dumpPath);
+          }
+        } catch (err: any) {
+          console.log("  %s Could not chmod ~/.pm2/dump.pm2: %s", WARN, err.message);
+        }
 
         const proc = await getBotProcess();
         const botErrored = proc && (proc.status === "errored" || proc.status === "stopped");

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { existsSync, readFileSync, chmodSync } from "fs";
+import { existsSync, readFileSync, chmodSync, statSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { execFileSync } from "child_process";
@@ -285,27 +285,55 @@ export function registerDoctorCommand(program: Command) {
             if (!existsSync(dumpPath)) {
               return "pass";
             }
+            // Mode is the primary defense. The regex is a soft signal — variable
+            // names like DATABASE_URL or PASSWORD slip past it, so a loose mode
+            // is unsafe regardless of regex. Anything readable by group or other
+            // (any of the low 6 bits set) means another local user can read the
+            // plaintext env snapshot.
+            let modeBits: number | null = null;
+            try {
+              modeBits = statSync(dumpPath).mode & 0o077;
+            } catch (err: any) {
+              console.log("    Could not stat dump file: %s", err.message);
+              return "warn";
+            }
+            const looseMode = modeBits !== 0;
+
+            let regexHit = false;
             try {
               const contents = readFileSync(dumpPath, "utf-8");
               const secretPattern = /TOKEN|KEY|SECRET|AUTH|SESSION|WEBHOOK/i;
-              if (secretPattern.test(contents)) {
-                console.log(
-                  "    %s may contain plaintext secrets (dotenv-loaded env vars are snapshotted by `pm2 save`).",
-                  dumpPath,
-                );
-                console.log(
-                  "    Recommend rotating affected secrets, then re-running `pm2 save` after secret hygiene.",
-                );
-                console.log(
-                  "    Run `chris doctor --fix` to chmod 600 the dump file.",
-                );
-                return "warn";
-              }
-              return "pass";
+              regexHit = secretPattern.test(contents);
             } catch (err: any) {
               console.log("    Could not read dump file: %s", err.message);
               return "warn";
             }
+
+            if (!looseMode && !regexHit) {
+              return "pass";
+            }
+
+            if (looseMode) {
+              const octal = (statSync(dumpPath).mode & 0o777).toString(8).padStart(3, "0");
+              console.log(
+                "    %s is mode %s — readable by group/other (plaintext env snapshot exposed to local users).",
+                dumpPath,
+                octal,
+              );
+            }
+            if (regexHit) {
+              console.log(
+                "    %s contents match common secret-name patterns (TOKEN|KEY|SECRET|AUTH|SESSION|WEBHOOK).",
+                dumpPath,
+              );
+            }
+            console.log(
+              "    pm2 save snapshots dotenv-loaded env, not just vars passed to `pm2 start` — non-matching names (DATABASE_URL, PASSWORD, etc.) are still exposed.",
+            );
+            console.log(
+              "    Run `chris doctor --fix` to chmod 600 the dump file. Rotate any secrets that sat at a loose mode.",
+            );
+            return "warn";
           },
         },
       ];


### PR DESCRIPTION
## Summary
Adds the `chris doctor` dump.pm2 guard from issue #95 (first sub-item only).

- New \`Check\` entry runs unconditionally on every \`chris doctor\` invocation: if \`~/.pm2/dump.pm2\` exists, reads it and matches \`/TOKEN|KEY|SECRET|AUTH|SESSION|WEBHOOK/i\` against contents; emits a \`warn\` with rotation guidance + hint to use \`--fix\`
- The chmod side runs only under \`--fix\` (idempotent \`chmodSync(path, 0o600)\`), placed at the top of the auto-fix block before the bot-status branch so it runs whether or not the bot is online
- Code comment near the new check explains why \`pm2 save\` snapshots dotenv-loaded secrets (not just vars explicitly passed to \`pm2 start\`) and why mode 0644 is dangerous

This intentionally does NOT touch the other three sub-items in #95 (symphony run-once leak, Telegram webhook mode, secret-rotation ops confirmation) — those are separate work. Issue stays open.

Refs #95

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 21 files, 185 tests, all green
- [ ] Manual: run \`chris doctor\` against a real \`~/.pm2/dump.pm2\` (with secrets) and confirm the warning fires
- [ ] Manual: run \`chris doctor --fix\` and confirm \`stat -f '%Lp' ~/.pm2/dump.pm2\` is \`600\`

## Files
- \`src/cli/commands/doctor.ts\` (+48 / -1)

🤖 Generated by autonomous refactor agent