### PR TITLE
fix(symphony): clean up run-once child processes on exit (#95)

### DIFF
--- a/src/symphony/codex/app-server.ts
+++ b/src/symphony/codex/app-server.ts
@@ -48,6 +48,7 @@ export class CodexAppServerSession {
       cwd: this.workspacePath,
       stdio: ["pipe", "pipe", "pipe"],
       env: process.env,
+      detached: true,
     });
 
     this.child.stderr.setEncoding("utf-8");
@@ -139,7 +140,9 @@ export class CodexAppServerSession {
   stop(): void {
     if (this.closed) return;
     this.closed = true;
-    this.child.kill("SIGTERM");
+    // run-once leaked 40+ codex children over weeks: killing the sh wrapper
+    // left codex orphaned. Kill the whole process group so codex dies with sh.
+    killProcessTree(this.child.pid);
   }
 
   private send(payload: Record<string, unknown>): void {
@@ -500,6 +503,20 @@ function looksLikePath(value: string): boolean {
   if (trimmed.includes("\n")) return false;
   if (trimmed === "." || trimmed === ".." || trimmed.startsWith("/") || trimmed.startsWith("~/")) return true;
   return trimmed.includes("/") || trimmed.includes("\\") || trimmed.startsWith(".");
+}
+
+function killProcessTree(pid: number | undefined): void {
+  if (!pid) return;
+  try {
+    // Negative pid targets the whole process group created by detached:true.
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // already exited
+    }
+  }
 }
 
 function isPathInsideWorkspace(candidatePath: string, workspacePath: string): boolean {

--- a/src/symphony/index.ts
+++ b/src/symphony/index.ts
@@ -16,24 +16,34 @@ async function main(): Promise<void> {
   const { once, workflowPath } = parseArgs(process.argv.slice(2));
   const runtime = createSymphonyRuntime(workflowPath);
 
-  const shutdown = async () => {
-    await runtime.stop();
-    process.exit(0);
+  let shuttingDown = false;
+  const shutdown = async (code = 0) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    try {
+      await runtime.stop();
+    } catch (err) {
+      console.error("[symphony] shutdown error:", err);
+    }
+    process.exit(code);
   };
 
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", () => void shutdown(0));
+  process.on("SIGTERM", () => void shutdown(0));
+  process.on("SIGHUP", () => void shutdown(0));
 
   if (once) {
     await runtime.runOnce();
-    await runtime.stop();
+    // run-once was leaking child processes; force-exit guarantees codex
+    // children are torn down even if a handle keeps the loop alive.
+    await shutdown(0);
     return;
   }
 
   await runtime.start();
 }
 
-main().catch((err) => {
+main().catch(async (err) => {
   console.error("[symphony] Fatal error:", err);
   process.exit(1);
 });

--- a/src/symphony/orchestrator.ts
+++ b/src/symphony/orchestrator.ts
@@ -99,9 +99,14 @@ export class SymphonyOrchestrator {
       }
     }
     this.retries.clear();
+    const pending: Promise<unknown>[] = [];
     for (const entry of this.running.values()) {
       entry.handle.stop("orchestrator shutdown");
+      pending.push(entry.handle.promise.catch(() => null));
     }
+    // Await runners so codex children finish tearing down before we exit.
+    await Promise.all(pending);
+    this.running.clear();
   }
 
   snapshot(): SymphonySnapshot {


### PR DESCRIPTION
## Root cause

`symphony run-once` spawned codex via `spawn("sh", ["-lc", cmd])` without `detached`, so the actual codex binary was a grandchild of the symphony process. `session.stop()` only sent `SIGTERM` to the `sh` wrapper — the codex child was not part of an addressable process group, so it was not always torn down. When the symphony parent was killed externally (cron/pm2 `SIGKILL` rather than `SIGTERM`), no graceful shutdown ran and codex was reparented to launchd. 40 orphans (16 parents + 24 children) accumulated over ~5 weeks.

Two compounding issues hid this:
1. `orchestrator.stop()` called `entry.handle.stop()` but did not await the runner promise, so the process could exit before children finished tearing down.
2. `index.ts` returned from `runOnce` without `process.exit()`, so a lingering handle (e.g. an unresolved codex turn timeout) could keep the loop alive while children leaked.

## Fix

- Spawn codex with `detached: true` and kill the whole process group on stop (`process.kill(-pid, "SIGTERM")`), so codex dies with its `sh` wrapper.
- Make `orchestrator.stop()` await in-flight runner promises before returning.
- Idempotent shutdown handler in `src/symphony/index.ts`, add `SIGHUP`, and force `process.exit(0)` after `runOnce` completes.

No production touch — `symphony run-once` was not exercised end-to-end.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — all 185 tests pass (existing symphony tests unchanged)
- [ ] Next live run-once: confirm no orphan `tsx`/`sh`/codex processes remain after exit

Closes part of #95.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>