### PR TITLE
feat(telegram): add opt-in webhook transport (#95)

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -40,6 +40,6 @@ export async function stopApp(): Promise<void> {
     runtimeStarted = false;
   }
 
-  stopTelegram();
+  await stopTelegram();
   await preTelegramRegistry.stopAll();
 }

--- a/src/channels/telegram/index.ts
+++ b/src/channels/telegram/index.ts
@@ -1,7 +1,18 @@
 import { GrammyError } from "grammy";
+import { config } from "../../config.js";
 import { bot } from "./bot.js";
 import { TELEGRAM_COMMAND_MENU, registerTelegramCommands } from "./commands.js";
 import { registerTelegramMessageHandlers } from "./handlers.js";
+import { startWebhook, type WebhookRuntime } from "./webhook.js";
+
+// Transport selection (env vars):
+//   TELEGRAM_TRANSPORT       = "polling" (default) | "webhook"
+//   TELEGRAM_WEBHOOK_URL     = https://… public URL Telegram will POST to (webhook only)
+//   TELEGRAM_WEBHOOK_SECRET  = shared secret; required when transport=webhook
+//   TELEGRAM_WEBHOOK_PORT    = local listen port (default 8443)
+// Telegram only accepts HTTPS webhook URLs, so the user must front the local
+// port with TLS termination (Cloudflare tunnel, ngrok, reverse proxy). This
+// module listens plain HTTP on the loopback port the tunnel forwards to.
 
 registerTelegramCommands(bot);
 registerTelegramMessageHandlers(bot);
@@ -16,9 +27,11 @@ export async function setTelegramCommandMenu(): Promise<void> {
 // slot, Telegram's 30s long-poll needs to expire before we can reclaim it.
 const POLL_CONFLICT_BACKOFF_MS = 35_000;
 
+let activeWebhook: WebhookRuntime | null = null;
+
 export function startTelegram(onStart: (botInfo: any) => void): void {
   // Downstream services (health monitor, timers, alert on startup) are not
-  // all idempotent, so only fire onStart for the first successful poll.
+  // all idempotent, so only fire onStart for the first successful start.
   let onStartFired = false;
   const fireOnStartOnce = (info: Parameters<typeof onStart>[0]): void => {
     if (onStartFired) return;
@@ -27,9 +40,14 @@ export function startTelegram(onStart: (botInfo: any) => void): void {
   };
 
   const onFatal = (err: any): void => {
-    console.error("[telegram] fatal polling error:", err?.message ?? err);
+    console.error("[telegram] fatal start error:", err?.message ?? err);
     process.exit(1);
   };
+
+  if (config.telegram.transport === "webhook") {
+    startWebhookTransport(fireOnStartOnce).catch(onFatal);
+    return;
+  }
 
   const run = async (): Promise<void> => {
     try {
@@ -49,6 +67,37 @@ export function startTelegram(onStart: (botInfo: any) => void): void {
   run().catch(onFatal);
 }
 
-export function stopTelegram(): void {
+async function startWebhookTransport(fireOnStartOnce: (info: any) => void): Promise<void> {
+  // Validated at config load, but narrow types here for the local closure.
+  const url = config.telegram.webhookUrl;
+  const secret = config.telegram.webhookSecret;
+  if (!url || !secret) {
+    throw new Error("telegram webhook transport selected but URL/secret are missing");
+  }
+
+  activeWebhook = await startWebhook({
+    url,
+    secret,
+    port: config.telegram.webhookPort,
+  });
+
+  const me = await bot.api.getMe();
+  console.log(`[telegram] webhook listening on :${config.telegram.webhookPort}, registered ${url}`);
+  fireOnStartOnce(me);
+}
+
+export async function stopTelegram(): Promise<void> {
+  if (config.telegram.transport === "webhook") {
+    if (activeWebhook) {
+      try {
+        await bot.api.deleteWebhook();
+      } catch (err: any) {
+        console.warn("[telegram] deleteWebhook failed:", err?.message ?? err);
+      }
+      await activeWebhook.close();
+      activeWebhook = null;
+    }
+    return;
+  }
   bot.stop();
 }

--- a/src/channels/telegram/webhook-verify.ts
+++ b/src/channels/telegram/webhook-verify.ts
@@ -1,0 +1,10 @@
+// Telegram stamps every delivery with X-Telegram-Bot-Api-Secret-Token when
+// secret_token is set on setWebhook — verifying it rejects forged updates from
+// anyone who guesses the public URL but not the secret.
+export function verifySecretHeader(
+  headerValue: string | string[] | undefined,
+  expected: string,
+): boolean {
+  if (typeof headerValue !== "string") return false;
+  return headerValue === expected;
+}

--- a/src/channels/telegram/webhook-verify.ts
+++ b/src/channels/telegram/webhook-verify.ts
@@ -1,10 +1,16 @@
+import { timingSafeEqual } from "node:crypto";
+
 // Telegram stamps every delivery with X-Telegram-Bot-Api-Secret-Token when
 // secret_token is set on setWebhook — verifying it rejects forged updates from
-// anyone who guesses the public URL but not the secret.
+// anyone who guesses the public URL but not the secret. Compared in constant
+// time so an attacker can't probe the secret one byte at a time via timing.
 export function verifySecretHeader(
   headerValue: string | string[] | undefined,
   expected: string,
 ): boolean {
   if (typeof headerValue !== "string") return false;
-  return headerValue === expected;
+  const a = Buffer.from(headerValue);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
 }

--- a/src/channels/telegram/webhook.ts
+++ b/src/channels/telegram/webhook.ts
@@ -1,0 +1,68 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { webhookCallback } from "grammy";
+import { bot } from "./bot.js";
+import { verifySecretHeader } from "./webhook-verify.js";
+
+export interface WebhookRuntime {
+  server: Server;
+  // Stop the http listener; setWebhook is cleared separately so callers control
+  // ordering between Telegram-side teardown and local socket close.
+  close: () => Promise<void>;
+}
+
+const SECRET_HEADER = "x-telegram-bot-api-secret-token";
+
+export { verifySecretHeader };
+
+export async function startWebhook(opts: {
+  url: string;
+  secret: string;
+  port: number;
+}): Promise<WebhookRuntime> {
+  // Path is secret-derived so a casual scan of the listening port can't even
+  // reach the grammy handler — defense in depth alongside the header check.
+  const path = `/telegram/${opts.secret}`;
+  const handle = webhookCallback(bot, "http", { secretToken: opts.secret });
+
+  const requestHandler = (req: IncomingMessage, res: ServerResponse): void => {
+    if (req.method !== "POST" || req.url !== path) {
+      res.statusCode = 401;
+      res.end();
+      return;
+    }
+    if (!verifySecretHeader(req.headers[SECRET_HEADER], opts.secret)) {
+      res.statusCode = 401;
+      res.end();
+      return;
+    }
+    Promise.resolve(handle(req, res)).catch((err) => {
+      console.error("[telegram] webhook handler error:", err?.message ?? err);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.end();
+      }
+    });
+  };
+
+  const server = createServer(requestHandler);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts.port, () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  await bot.api.setWebhook(opts.url, {
+    secret_token: opts.secret,
+    allowed_updates: ["message", "edited_message", "callback_query", "channel_post"],
+  });
+
+  return {
+    server,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/src/infra/config/load-config.ts
+++ b/src/infra/config/load-config.ts
@@ -27,6 +27,13 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): { config: AppC
   const memoryRepo = values.GITHUB_MEMORY_REPO;
   const [owner, name] = memoryRepo.split("/");
 
+  const transport = values.TELEGRAM_TRANSPORT ?? "polling";
+  if (transport === "webhook" && (!values.TELEGRAM_WEBHOOK_URL || !values.TELEGRAM_WEBHOOK_SECRET)) {
+    throw new Error(
+      "Invalid configuration: TELEGRAM_TRANSPORT=webhook requires both TELEGRAM_WEBHOOK_URL and TELEGRAM_WEBHOOK_SECRET",
+    );
+  }
+
   const model = values.AI_MODEL || values.CLAUDE_MODEL || "gpt-4o";
   try {
     strictProviderForModel(model);
@@ -42,6 +49,10 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): { config: AppC
         botToken: values.TELEGRAM_BOT_TOKEN,
         allowedUserId: values.TELEGRAM_ALLOWED_USER_ID,
         allowBotMessages: values.TELEGRAM_ALLOW_BOT_MESSAGES ?? false,
+        transport,
+        webhookUrl: normalizeOptional(values.TELEGRAM_WEBHOOK_URL),
+        webhookSecret: normalizeOptional(values.TELEGRAM_WEBHOOK_SECRET),
+        webhookPort: values.TELEGRAM_WEBHOOK_PORT ?? 8443,
       },
       github: {
         token: values.GITHUB_TOKEN,

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -10,6 +10,14 @@ export const envSchema = z.object({
   TELEGRAM_BOT_TOKEN: envString,
   TELEGRAM_ALLOWED_USER_ID: z.coerce.number().int(),
   TELEGRAM_ALLOW_BOT_MESSAGES: z.coerce.boolean().optional(),
+  TELEGRAM_TRANSPORT: z.enum(["polling", "webhook"]).optional(),
+  TELEGRAM_WEBHOOK_URL: z
+    .string()
+    .url()
+    .refine((u) => u.startsWith("https://"), "must be HTTPS")
+    .optional(),
+  TELEGRAM_WEBHOOK_SECRET: z.string().min(1).optional(),
+  TELEGRAM_WEBHOOK_PORT: z.coerce.number().int().positive().optional(),
   GITHUB_TOKEN: envString,
   GITHUB_MEMORY_REPO: envString.regex(/^[^/]+\/[^/]+$/, "Expected owner/repo format"),
   DISCORD_BOT_TOKEN: z.string().optional(),

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -16,7 +16,7 @@ export const envSchema = z.object({
     .url()
     .refine((u) => u.startsWith("https://"), "must be HTTPS")
     .optional(),
-  TELEGRAM_WEBHOOK_SECRET: z.string().min(1).optional(),
+  TELEGRAM_WEBHOOK_SECRET: z.string().min(1).max(256).optional(),
   TELEGRAM_WEBHOOK_PORT: z.coerce.number().int().positive().optional(),
   GITHUB_TOKEN: envString,
   GITHUB_MEMORY_REPO: envString.regex(/^[^/]+\/[^/]+$/, "Expected owner/repo format"),

--- a/src/infra/config/types.ts
+++ b/src/infra/config/types.ts
@@ -5,6 +5,10 @@ export interface AppConfig {
     botToken: string;
     allowedUserId: number;
     allowBotMessages: boolean;
+    transport: "polling" | "webhook";
+    webhookUrl: string | null;
+    webhookSecret: string | null;
+    webhookPort: number;
   };
   github: {
     token: string;

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -60,6 +60,45 @@ describe("loadConfig", () => {
     expect(() => loadConfig({})).toThrow(/TELEGRAM_BOT_TOKEN/);
   });
 
+  it("defaults telegram transport to polling", () => {
+    const { config } = loadConfig(baseEnv);
+    expect(config.telegram.transport).toBe("polling");
+    expect(config.telegram.webhookPort).toBe(8443);
+    expect(config.telegram.webhookUrl).toBeNull();
+    expect(config.telegram.webhookSecret).toBeNull();
+  });
+
+  it("accepts webhook transport with URL + secret", () => {
+    const { config } = loadConfig({
+      ...baseEnv,
+      TELEGRAM_TRANSPORT: "webhook",
+      TELEGRAM_WEBHOOK_URL: "https://bot.example.com/tg",
+      TELEGRAM_WEBHOOK_SECRET: "shh",
+      TELEGRAM_WEBHOOK_PORT: "9000",
+    });
+    expect(config.telegram.transport).toBe("webhook");
+    expect(config.telegram.webhookUrl).toBe("https://bot.example.com/tg");
+    expect(config.telegram.webhookSecret).toBe("shh");
+    expect(config.telegram.webhookPort).toBe(9000);
+  });
+
+  it("rejects webhook transport without URL or secret", () => {
+    expect(() =>
+      loadConfig({ ...baseEnv, TELEGRAM_TRANSPORT: "webhook" }),
+    ).toThrow(/TELEGRAM_WEBHOOK_URL/);
+  });
+
+  it("rejects non-https webhook URL", () => {
+    expect(() =>
+      loadConfig({
+        ...baseEnv,
+        TELEGRAM_TRANSPORT: "webhook",
+        TELEGRAM_WEBHOOK_URL: "http://bot.example.com/tg",
+        TELEGRAM_WEBHOOK_SECRET: "shh",
+      }),
+    ).toThrow(/HTTPS|Invalid configuration/);
+  });
+
   it("rejects invalid memory repo format", () => {
     expect(() =>
       loadConfig({

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { verifySecretHeader } from "../src/channels/telegram/webhook-verify.js";
+
+describe("verifySecretHeader", () => {
+  it("accepts a matching string header", () => {
+    expect(verifySecretHeader("abc123", "abc123")).toBe(true);
+  });
+
+  it("rejects a mismatched header", () => {
+    expect(verifySecretHeader("nope", "abc123")).toBe(false);
+  });
+
+  it("rejects missing or non-string headers", () => {
+    expect(verifySecretHeader(undefined, "abc123")).toBe(false);
+    expect(verifySecretHeader(["abc123"], "abc123")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `TELEGRAM_TRANSPORT=polling|webhook` (default `polling`, no behavior change).
- When `webhook`, starts a Node HTTP server on `TELEGRAM_WEBHOOK_PORT` (default `8443`), mounts grammy's `webhookCallback(bot, "http")` at a secret-derived path, calls `setWebhook` with `secret_token`, and rejects any request whose `X-Telegram-Bot-Api-Secret-Token` header doesn't match.
- `stopTelegram` is now async — webhook path calls `deleteWebhook()` then closes the http server; polling path is unchanged.

## Why

Sidesteps the long-poll `getUpdates` 409 slot conflict that crashed the bot in the 2026-04-19 incident (see #92, #95). Webhook delivery removes the shared-slot exposure entirely.

## Required ops setup (not in this PR)

Telegram only accepts HTTPS webhook URLs. This PR is **code-only** — the webhook server listens plain HTTP on a local port. Before flipping `TELEGRAM_TRANSPORT=webhook` in production, the user must front the port with HTTPS (Cloudflare tunnel, ngrok, or reverse proxy) and point `TELEGRAM_WEBHOOK_URL` at the public HTTPS endpoint.

Env to add when ready:

```
TELEGRAM_TRANSPORT=webhook
TELEGRAM_WEBHOOK_URL=https://<your-public-host>/telegram/<secret>
TELEGRAM_WEBHOOK_SECRET=<random-32+-char-secret>
TELEGRAM_WEBHOOK_PORT=8443
```

The local path is `/telegram/${TELEGRAM_WEBHOOK_SECRET}`; whatever fronts it must forward POSTs at the matching public path.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (192 passed, 7 new — config-loader transport validation + webhook-verify unit tests)
- [ ] Manual: with default env, polling still starts and accepts messages
- [ ] Manual: with `TELEGRAM_TRANSPORT=webhook` + tunnel, webhook delivers messages and `setWebhook`/`deleteWebhook` round-trip on shutdown
- [ ] Manual: a POST without `X-Telegram-Bot-Api-Secret-Token` returns 401