### PR TITLE
fix(symphony): bound orchestrator.stop() with shutdown timeout (#101)

### DIFF
--- a/src/symphony/agent-runner.ts
+++ b/src/symphony/agent-runner.ts
@@ -24,7 +24,7 @@ export class AgentRunner {
   ) {}
 
   run(issue: Issue, attempt: number, onUpdate?: (update: AppServerUpdate) => void): RunnerHandle {
-    const sessionHolder: { stop?: () => void } = {};
+    const sessionHolder: { stop?: () => void; forceKill?: () => void } = {};
 
     const promise = (async (): Promise<IssueRunResult> => {
       const workspace = await this.workspaceManager.createForIssue(issue);
@@ -51,6 +51,7 @@ export class AgentRunner {
         );
 
         sessionHolder.stop = () => session.stop();
+        sessionHolder.forceKill = () => session.forceKill();
         const meta = await session.start();
         threadId = meta.threadId;
 
@@ -106,6 +107,10 @@ export class AgentRunner {
       stop(reason?: string) {
         appendIssueLog(issue.identifier, `[runner-stop] ${reason || "stop requested"}`);
         sessionHolder.stop?.();
+      },
+      forceKill(reason?: string) {
+        appendIssueLog(issue.identifier, `[runner-force-kill] ${reason || "force kill requested"}`);
+        sessionHolder.forceKill?.();
       },
     };
   }

--- a/src/symphony/codex/app-server.ts
+++ b/src/symphony/codex/app-server.ts
@@ -145,6 +145,13 @@ export class CodexAppServerSession {
     killProcessTree(this.child.pid);
   }
 
+  forceKill(): void {
+    // Escape hatch for shutdown timeouts: SIGKILL the whole process group
+    // when SIGTERM (stop) didn't trigger a turn/completed within the budget.
+    this.closed = true;
+    killProcessTree(this.child.pid, "SIGKILL");
+  }
+
   private send(payload: Record<string, unknown>): void {
     this.child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", ...payload })}\n`);
   }
@@ -505,14 +512,14 @@ function looksLikePath(value: string): boolean {
   return trimmed.includes("/") || trimmed.includes("\\") || trimmed.startsWith(".");
 }
 
-function killProcessTree(pid: number | undefined): void {
+function killProcessTree(pid: number | undefined, signal: NodeJS.Signals = "SIGTERM"): void {
   if (!pid) return;
   try {
     // Negative pid targets the whole process group created by detached:true.
-    process.kill(-pid, "SIGTERM");
+    process.kill(-pid, signal);
   } catch {
     try {
-      process.kill(pid, "SIGTERM");
+      process.kill(pid, signal);
     } catch {
       // already exited
     }

--- a/src/symphony/orchestrator.ts
+++ b/src/symphony/orchestrator.ts
@@ -24,6 +24,17 @@ import type {
 const CI_FEEDBACK_WAIT_TIMEOUT_MS = 60_000;
 const CI_FEEDBACK_POLL_INTERVAL_MS = 5_000;
 
+// Bound shutdown so SIGINT/SIGTERM mid-turn can't block on turnTimeoutMs (1hr default)
+// when the codex child fails to emit turn/completed after process-group SIGTERM.
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+function getShutdownTimeoutMs(): number {
+  const raw = process.env.SYMPHONY_SHUTDOWN_TIMEOUT_MS;
+  if (!raw) return DEFAULT_SHUTDOWN_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SHUTDOWN_TIMEOUT_MS;
+}
+
 interface RetryEntry {
   issue: Issue;
   attempt: number;
@@ -99,13 +110,42 @@ export class SymphonyOrchestrator {
       }
     }
     this.retries.clear();
-    const pending: Promise<unknown>[] = [];
+    const pending: Array<{ identifier: string; entry: RunningEntry; settled: boolean }> = [];
+    const promises: Promise<unknown>[] = [];
     for (const entry of this.running.values()) {
       entry.handle.stop("orchestrator shutdown");
-      pending.push(entry.handle.promise.catch(() => null));
+      const item = { identifier: entry.issue.identifier, entry, settled: false };
+      pending.push(item);
+      promises.push(entry.handle.promise.catch(() => null).finally(() => {
+        item.settled = true;
+      }));
     }
-    // Await runners so codex children finish tearing down before we exit.
-    await Promise.all(pending);
+
+    // Await runners so codex children finish tearing down before we exit, but
+    // bound the wait: if codex doesn't emit turn/completed after SIGTERM, the
+    // runner promise can otherwise block on turnTimeoutMs (1hr default).
+    const timeoutMs = getShutdownTimeoutMs();
+    const TIMED_OUT = Symbol("shutdown-timeout");
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const timeoutPromise = new Promise<typeof TIMED_OUT>((resolve) => {
+      timer = setTimeout(() => resolve(TIMED_OUT), timeoutMs);
+    });
+
+    const all = Promise.all(promises).then(() => "ok" as const);
+    const outcome = await Promise.race([all, timeoutPromise]);
+    if (timer) clearTimeout(timer);
+
+    if (outcome === TIMED_OUT) {
+      const stragglers = pending.filter((item) => !item.settled);
+      console.warn(
+        `[symphony] shutdown timed out after ${timeoutMs}ms; force-killing runners:`,
+        stragglers.map((item) => item.identifier),
+      );
+      for (const item of stragglers) {
+        item.entry.handle.forceKill?.("orchestrator shutdown timeout");
+      }
+    }
+
     this.running.clear();
   }
 

--- a/src/symphony/types.ts
+++ b/src/symphony/types.ts
@@ -142,6 +142,7 @@ export interface IssueRunResult {
 export interface RunnerHandle {
   promise: Promise<IssueRunResult>;
   stop(reason?: string): void;
+  forceKill?(reason?: string): void;
 }
 
 export interface RetryEntrySnapshot {

--- a/tests/symphony-orchestrator.test.ts
+++ b/tests/symphony-orchestrator.test.ts
@@ -256,4 +256,72 @@ describe("SymphonyOrchestrator", () => {
       await orchestrator.stop();
     });
   });
+
+  it("bounds stop() with a shutdown timeout and force-kills stragglers", async () => {
+    await withTempHome(async () => {
+      const { SymphonyOrchestrator } = await import("../src/symphony/orchestrator.js");
+      const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "symphony-orchestrator-"));
+      cleanupPaths.push(workspaceRoot);
+
+      const tracker: Tracker = {
+        async fetchCandidateIssues() { return []; },
+        async fetchIssuesByStates() { return []; },
+        async fetchIssueStatesByIds() { return []; },
+        async createComment() {},
+        async updateIssueState() {},
+      };
+
+      const orchestrator = new SymphonyOrchestrator(
+        makeDefinition(path.join(workspaceRoot, "WORKFLOW.md")),
+        makeConfig(workspaceRoot),
+        tracker,
+        DYNAMIC_TOOLS,
+      );
+
+      // Inject a fake running entry whose handle.promise never resolves, the
+      // shape orchestrator.stop() would otherwise wait turnTimeoutMs (1hr) for.
+      const issue = makeIssue();
+      let stopCalled = false;
+      let forceKillCalled = false;
+      const handle = {
+        promise: new Promise<never>(() => { /* never resolves */ }),
+        stop() { stopCalled = true; },
+        forceKill() { forceKillCalled = true; },
+      };
+      (orchestrator as any).running.set(issue.id, {
+        issue,
+        attempt: 0,
+        startedAt: Date.now(),
+        handle,
+        workspacePath: null,
+        threadId: null,
+        turnId: null,
+        lastEvent: null,
+        lastMessage: null,
+      });
+
+      const previousTimeout = process.env.SYMPHONY_SHUTDOWN_TIMEOUT_MS;
+      process.env.SYMPHONY_SHUTDOWN_TIMEOUT_MS = "100";
+      const warnings: unknown[][] = [];
+      const previousWarn = console.warn;
+      console.warn = (...args: unknown[]) => { warnings.push(args); };
+      try {
+        const startedAt = Date.now();
+        await orchestrator.stop();
+        const elapsed = Date.now() - startedAt;
+        expect(elapsed).toBeLessThan(2_000);
+        expect(stopCalled).toBe(true);
+        expect(forceKillCalled).toBe(true);
+        expect(warnings.some((w) => String(w[0]).includes("shutdown timed out"))).toBe(true);
+        expect((orchestrator as any).running.size).toBe(0);
+      } finally {
+        console.warn = previousWarn;
+        if (previousTimeout === undefined) {
+          delete process.env.SYMPHONY_SHUTDOWN_TIMEOUT_MS;
+        } else {
+          process.env.SYMPHONY_SHUTDOWN_TIMEOUT_MS = previousTimeout;
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Bounds `SymphonyOrchestrator.stop()` so SIGINT/SIGTERM mid-turn can no longer hang up to `turnTimeoutMs` (1 hour default) when codex doesn't emit `turn/completed` after process-group SIGTERM. Races `Promise.all(pending)` against a short shutdown timeout (default 5s, configurable via `SYMPHONY_SHUTDOWN_TIMEOUT_MS`).
- Adds `CodexAppServerSession.forceKill()` (SIGKILL the whole process group), plumbed through `RunnerHandle.forceKill()`. Stragglers are force-killed after the timeout, with a warning naming them.
- Happy path is unchanged: in-flight runners are still awaited so children tear down cleanly before exit. Only diverges when the await would otherwise block past the timeout.

Context: follow-up from PR #100 review thread (Codex P1 — `await Promise.all(pending)` could hang if the codex child doesn't emit `turn/completed` after SIGTERM).

Closes #101.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 193 tests pass (185 prior + 8 added by other PRs since branch base; new test for the timed-out shutdown path is included)
- [x] New unit test injects a fake runner whose `handle.promise` never resolves, sets `SYMPHONY_SHUTDOWN_TIMEOUT_MS=100`, asserts `stop()` returns within 2s, `forceKill` is invoked, and the warning is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)