### PR TITLE
feat(telegram): inline keyboard buttons for confirmations (#66)

### DIFF
--- a/src/channels/telegram/callback-data.ts
+++ b/src/channels/telegram/callback-data.ts
@@ -1,0 +1,28 @@
+// Callback data is capped at 64 bytes by Telegram. Keep the namespace short
+// and only encode action verbs — never user-controlled text.
+const NAMESPACE = "ca";
+const SEP = ":";
+
+export type CallbackAction = "purge:yes" | "purge:no" | "restart:yes" | "restart:no";
+
+const ACTIONS: ReadonlySet<string> = new Set([
+  "purge:yes",
+  "purge:no",
+  "restart:yes",
+  "restart:no",
+]);
+
+export function encodeCallback(action: CallbackAction): string {
+  return NAMESPACE + SEP + action;
+}
+
+// Returns null for any payload that did not originate from this module — the
+// allowlist is the auth boundary for the callback router, so unknown actions
+// are dropped without dispatch.
+export function parseCallbackData(data: string | undefined): CallbackAction | null {
+  if (!data) return null;
+  const prefix = NAMESPACE + SEP;
+  if (!data.startsWith(prefix)) return null;
+  const action = data.slice(prefix.length);
+  return ACTIONS.has(action) ? (action as CallbackAction) : null;
+}

--- a/src/channels/telegram/callbacks.ts
+++ b/src/channels/telegram/callbacks.ts
@@ -1,0 +1,91 @@
+import type { Bot, Context } from "grammy";
+import { InlineKeyboard } from "grammy";
+import { clearHistory } from "../../conversation.js";
+import { chatService } from "../../agent/chat-service.js";
+import { datestamp, redactArchiveEntries, uploadArchives } from "../../conversation-archive.js";
+import { encodeCallback, parseCallbackData } from "./callback-data.js";
+
+export function purgeConfirmKeyboard(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text("Yes, purge", encodeCallback("purge:yes"))
+    .text("Cancel", encodeCallback("purge:no"));
+}
+
+export function restartConfirmKeyboard(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text("Yes, restart", encodeCallback("restart:yes"))
+    .text("Cancel", encodeCallback("restart:no"));
+}
+
+async function clearKeyboard(ctx: Context): Promise<void> {
+  if (!ctx.callbackQuery?.message) return;
+  await ctx.api
+    .editMessageReplyMarkup(
+      ctx.callbackQuery.message.chat.id,
+      ctx.callbackQuery.message.message_id,
+      { reply_markup: { inline_keyboard: [] } },
+    )
+    .catch(() => {});
+}
+
+export function registerTelegramCallbackHandlers(bot: Bot<Context>): void {
+  bot.on("callback_query:data", async (ctx) => {
+    const action = parseCallbackData(ctx.callbackQuery.data);
+
+    if (!action) {
+      // Always answer to clear the spinner, even on unknown payloads.
+      await ctx.answerCallbackQuery().catch(() => {});
+      return;
+    }
+
+    const chatId = ctx.callbackQuery.message?.chat.id;
+    if (chatId === undefined) {
+      await ctx.answerCallbackQuery().catch(() => {});
+      return;
+    }
+
+    switch (action) {
+      case "purge:yes": {
+        await clearHistory(chatId);
+        chatService.clearSession(chatId);
+        const today = datestamp();
+        const removed = redactArchiveEntries(chatId, today);
+        if (removed > 0) {
+          uploadArchives().catch((err: any) => {
+            console.error("[telegram] Failed to upload redacted archive:", err.message);
+          });
+        }
+        await clearKeyboard(ctx);
+        await ctx.answerCallbackQuery({ text: "Purged" }).catch(() => {});
+        await ctx.reply(
+          removed > 0
+            ? `Conversation purged. ${removed} archive entries removed from today's log.`
+            : "Conversation cleared. No archive entries found for today.",
+        );
+        return;
+      }
+
+      case "purge:no": {
+        await clearKeyboard(ctx);
+        await ctx.answerCallbackQuery({ text: "Cancelled" }).catch(() => {});
+        await ctx.reply("Purge cancelled.");
+        return;
+      }
+
+      case "restart:yes": {
+        await clearKeyboard(ctx);
+        await ctx.answerCallbackQuery({ text: "Restarting" }).catch(() => {});
+        await ctx.reply("Restarting... back in a few seconds.");
+        setTimeout(() => process.exit(0), 1500);
+        return;
+      }
+
+      case "restart:no": {
+        await clearKeyboard(ctx);
+        await ctx.answerCallbackQuery({ text: "Cancelled" }).catch(() => {});
+        await ctx.reply("Restart cancelled.");
+        return;
+      }
+    }
+  });
+}

--- a/src/channels/telegram/commands.ts
+++ b/src/channels/telegram/commands.ts
@@ -7,9 +7,9 @@ import { readMemoryFile } from "../../memory/github.js";
 import { invalidatePromptCache } from "../../providers/shared.js";
 import { providerDisplayName } from "../../providers/model-routing.js";
 import { getWorkspaceRoot, setWorkspaceRoot, isProjectActive } from "../../tools/files.js";
-import { datestamp, redactArchiveEntries, uploadArchives } from "../../conversation-archive.js";
 import { chatService } from "../../agent/chat-service.js";
 import { dreamStatus, forceDream } from "../../domain/memory/dream-service.js";
+import { purgeConfirmKeyboard, restartConfirmKeyboard } from "./callbacks.js";
 
 export const TELEGRAM_COMMAND_MENU = [
   { command: "start", description: "Greeting" },
@@ -38,24 +38,9 @@ export function registerTelegramCommands(bot: Bot<Context>): void {
   });
 
   bot.command("purge", async (ctx) => {
-    const chatId = ctx.chat.id;
-
-    await clearHistory(chatId);
-    chatService.clearSession(chatId);
-
-    const today = datestamp();
-    const removed = redactArchiveEntries(chatId, today);
-
-    if (removed > 0) {
-      uploadArchives().catch((err: any) => {
-        console.error("[telegram] Failed to upload redacted archive:", err.message);
-      });
-    }
-
     await ctx.reply(
-      removed > 0
-        ? `Conversation purged. ${removed} archive entries removed from today's log.`
-        : "Conversation cleared. No archive entries found for today.",
+      "Purge will clear this conversation AND remove today's archive entries. Continue?",
+      { reply_markup: purgeConfirmKeyboard() },
     );
   });
 
@@ -108,8 +93,10 @@ export function registerTelegramCommands(bot: Bot<Context>): void {
   });
 
   bot.command("restart", async (ctx) => {
-    await ctx.reply("Restarting... back in a few seconds.");
-    setTimeout(() => process.exit(0), 1500);
+    await ctx.reply(
+      "Restart the bot now?",
+      { reply_markup: restartConfirmKeyboard() },
+    );
   });
 
   bot.command("dream", async (ctx) => {

--- a/src/channels/telegram/index.ts
+++ b/src/channels/telegram/index.ts
@@ -4,6 +4,7 @@ import { bot } from "./bot.js";
 import { TELEGRAM_COMMAND_MENU, registerTelegramCommands } from "./commands.js";
 import { registerTelegramMessageHandlers } from "./handlers.js";
 import { startWebhook, type WebhookRuntime } from "./webhook.js";
+import { registerTelegramCallbackHandlers } from "./callbacks.js";
 
 // Transport selection (env vars):
 //   TELEGRAM_TRANSPORT       = "polling" (default) | "webhook"
@@ -16,6 +17,7 @@ import { startWebhook, type WebhookRuntime } from "./webhook.js";
 
 registerTelegramCommands(bot);
 registerTelegramMessageHandlers(bot);
+registerTelegramCallbackHandlers(bot);
 
 export { bot };
 

--- a/tests/telegram-callbacks.test.ts
+++ b/tests/telegram-callbacks.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodeCallback,
+  parseCallbackData,
+} from "../src/channels/telegram/callback-data.js";
+
+describe("parseCallbackData", () => {
+  it("returns null for undefined", () => {
+    expect(parseCallbackData(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseCallbackData("")).toBeNull();
+  });
+
+  it("returns null for payloads without the namespace", () => {
+    expect(parseCallbackData("purge:yes")).toBeNull();
+    expect(parseCallbackData("foo:bar")).toBeNull();
+  });
+
+  it("returns null for unknown actions inside the namespace", () => {
+    expect(parseCallbackData("ca:nope")).toBeNull();
+    expect(parseCallbackData("ca:purge:maybe")).toBeNull();
+  });
+
+  it("parses each known action", () => {
+    expect(parseCallbackData("ca:purge:yes")).toBe("purge:yes");
+    expect(parseCallbackData("ca:purge:no")).toBe("purge:no");
+    expect(parseCallbackData("ca:restart:yes")).toBe("restart:yes");
+    expect(parseCallbackData("ca:restart:no")).toBe("restart:no");
+  });
+
+  it("round-trips through encodeCallback", () => {
+    const actions = ["purge:yes", "purge:no", "restart:yes", "restart:no"] as const;
+    for (const action of actions) {
+      expect(parseCallbackData(encodeCallback(action))).toBe(action);
+    }
+  });
+
+  it("keeps every encoded payload under Telegram's 64-byte cap", () => {
+    const actions = ["purge:yes", "purge:no", "restart:yes", "restart:no"] as const;
+    for (const action of actions) {
+      expect(Buffer.byteLength(encodeCallback(action), "utf-8")).toBeLessThanOrEqual(64);
+    }
+  });
+});


### PR DESCRIPTION
Closes #66.

## Summary

Retrofits two existing destructive Telegram commands with grammY `InlineKeyboard` confirm/cancel buttons. No new flows invented — both targets were already destructive text-only commands without any safeguard.

- `/purge` — was a one-shot destructive call; now prompts "Purge will clear this conversation AND remove today's archive entries. Continue?" with **Yes, purge** / **Cancel** buttons. The actual `clearHistory` + `redactArchiveEntries` + `uploadArchives` work runs in the callback handler.
- `/restart` — now prompts "Restart the bot now?" with **Yes, restart** / **Cancel**. The `process.exit(0)` runs in the callback handler.

## What changed

- `src/channels/telegram/callback-data.ts` (new) — pure encode/parse helpers. Namespaced as `ca:<action>` with an allowlist (`purge:yes`, `purge:no`, `restart:yes`, `restart:no`); unknown payloads return `null` and are dropped without dispatch. All payloads stay well under Telegram's 64-byte cap.
- `src/channels/telegram/callbacks.ts` (new) — `registerTelegramCallbackHandlers` wires `bot.on("callback_query:data", ...)`. Each handler answers the callback query (clears the spinner), edits the inline keyboard off the original message, and posts the outcome.
- `src/channels/telegram/commands.ts` — `/purge` and `/restart` now reply with confirm keyboards instead of acting immediately.
- `src/channels/telegram/index.ts` — register the callback handler alongside commands and message handlers.
- `tests/telegram-callbacks.test.ts` — covers `parseCallbackData` allowlist, namespace check, round-trip, and 64-byte cap.

## Auth

Reused. `authMiddleware` is already wired via `bot.use(authMiddleware)` in `bot.ts` and rejects any `ctx.from?.id !== TELEGRAM_ALLOWED_USER_ID` — that runs on `callback_query` updates the same way it runs on messages. No second check needed.

## Out of scope

The issue mentions "skills can return inline buttons alongside text responses." That requires reshaping the `chatService.sendMessage` return contract (currently a `string`) to carry a button payload, and threading it through every provider. That's a larger structural change touching `src/agent/`, `src/providers/`, and the dashboard mirror. I scoped down to retrofitting existing confirmations per the prompt's guidance — happy to follow up in a separate PR once the response shape is agreed.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm test` — 192/192 pass (185 existing + 7 new).
- [ ] Manual smoke (not yet manually verified):
  - [ ] Send `/purge` — confirm keyboard appears.
  - [ ] Tap **Cancel** — keyboard disappears, "Purge cancelled." message, conversation untouched.
  - [ ] Tap **Yes, purge** — keyboard disappears, conversation + today's archive cleared.
  - [ ] Send `/restart` — confirm keyboard appears.
  - [ ] Tap **Cancel** — keyboard disappears, "Restart cancelled.", bot stays up.
  - [ ] Tap **Yes, restart** — bot restarts.
  - [ ] Confirm an unauthorized user pressing a leftover button gets blocked by `authMiddleware` (no spinner hang either way — handler always answers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)