### PR TITLE
fix(telegram): keep all_private_chats command scope in sync with default

### DIFF
--- a/src/channels/telegram/index.ts
+++ b/src/channels/telegram/index.ts
@@ -58,7 +58,11 @@ export async function setTelegramCommandMenu(): Promise<void> {
     console.warn("[telegram] failed to load skill command plan:", err?.message ?? err);
     setActiveSkillRoutes(new Map());
   }
+  // Write both scopes: clients prefer scope-specific over default, so a stale
+  // all_private_chats list (set by an earlier code rev or BotFather) would
+  // otherwise hide the real menu in DMs. Keeping both in sync prevents drift.
   await bot.api.setMyCommands(entries);
+  await bot.api.setMyCommands(entries, { scope: { type: "all_private_chats" } });
 }
 
 // Retry on 409 instead of crashing — another poller occasionally steals the


### PR DESCRIPTION
## Summary
A stale \`all_private_chats\` scope list (3 entries: \`start\`, \`help\`, \`status\`) was overriding the real 12-entry default menu in DMs. Telegram clients prefer scope-specific commands over default, so the user only saw 3 commands in autocomplete despite \`getMyCommands\` (default) returning the full list.

## Fix
\`setTelegramCommandMenu()\` now writes the same entry list to **both** scopes on every call. Cheap (one extra Bot API call at startup and on skill-index changes) and prevents future drift.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 217 passing
- [x] Root cause confirmed by querying \`getMyCommands\` per scope (default: 12, all_private_chats: 3)
- [x] One-off \`deleteMyCommands(scope=all_private_chats)\` already restored the menu in the running bot; this PR codifies the prevention