### PR TITLE
feat(symphony): pluggable agent backend with Claude Code provider

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -44,6 +44,7 @@ agent:
   max_concurrent_agents: 2
   max_turns: 4
   max_retry_backoff_ms: 300000
+  # provider: claude-code  # Uncomment to use Claude Code sub-agents instead of Codex
 codex:
   command: "codex app-server"
   approval_policy:
@@ -52,6 +53,11 @@ codex:
       rules: true
       mcp_elicitations: true
   thread_sandbox: workspace-write
+# claude_code:
+#   model: claude-sonnet-4-6       # Default: AI_MODEL env or claude-sonnet-4-6
+#   max_turns_per_query: 20        # Optional cap on tool-call turns per AgentRunner turn
+#   system_prompt_append: |        # Optional extra text appended to the claude_code system prompt
+#     Always run npm run typecheck before moving to human-review.
 server:
   host: "127.0.0.1"
   port: 3010

--- a/src/symphony/agent-runner.ts
+++ b/src/symphony/agent-runner.ts
@@ -1,9 +1,12 @@
 import { buildTurnSandboxPolicy } from "./config.js";
 import { CodexAppServerSession } from "./codex/app-server.js";
+import { ClaudeCodeSession } from "./claude-code/session.js";
 import { appendIssueLog } from "./paths.js";
 import { renderWorkflowPrompt } from "./workflow.js";
 import { WorkspaceManager } from "./workspace.js";
 import type {
+  AppServerSessionMeta,
+  AppServerTurnResult,
   AppServerUpdate,
   DynamicToolHandler,
   Issue,
@@ -13,6 +16,26 @@ import type {
   Tracker,
   WorkflowDefinition,
 } from "./types.js";
+
+interface AgentSession {
+  start(): Promise<AppServerSessionMeta>;
+  runTurn(prompt: string): Promise<AppServerTurnResult>;
+  stop(): void;
+  forceKill(): void;
+}
+
+function createSession(
+  config: SymphonyConfig,
+  workspacePath: string,
+  issue: Issue,
+  dynamicTools: DynamicToolHandler,
+  onUpdate?: (update: AppServerUpdate) => void,
+): AgentSession {
+  if (config.agent.provider === "claude-code") {
+    return new ClaudeCodeSession(config, workspacePath, issue, dynamicTools, onUpdate);
+  }
+  return new CodexAppServerSession(config, workspacePath, issue, dynamicTools, onUpdate);
+}
 
 export class AgentRunner {
   constructor(
@@ -35,7 +58,7 @@ export class AgentRunner {
       let turnId: string | null = null;
 
       try {
-        const session = new CodexAppServerSession(
+        const session = createSession(
           this.config,
           workspace.path,
           issue,

--- a/src/symphony/claude-code/session.ts
+++ b/src/symphony/claude-code/session.ts
@@ -1,0 +1,173 @@
+import { query, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { appendIssueLog } from "../paths.js";
+import type {
+  AppServerSessionMeta,
+  AppServerTurnResult,
+  AppServerUpdate,
+  DynamicToolHandler,
+  Issue,
+  SymphonyConfig,
+} from "../types.js";
+
+function buildZodShape(schema: Record<string, unknown>): Record<string, z.ZodTypeAny> {
+  const properties = (schema.properties as Record<string, unknown>) ?? {};
+  return Object.fromEntries(Object.keys(properties).map((key) => [key, z.any()]));
+}
+
+const MCP_SERVER_NAME = "symphony-tools";
+
+const BLOCKED_BASH_PATTERNS = [
+  /\bpm2\b/i,
+  /\bkill\b.*chris-assistant/i,
+  /\bsystemctl\b.*(restart|stop|disable)/i,
+  /\breboot\b/,
+  /\bshutdown\b/,
+  /\brm\s+-rf\s+[/~]/,
+];
+
+async function safetyHook(input: any): Promise<any> {
+  if (input.hook_event_name !== "PreToolUse") return { continue: true };
+  if (input.tool_name !== "Bash") return { continue: true };
+  const command = input.tool_input?.command;
+  if (typeof command !== "string") return { continue: true };
+  for (const pattern of BLOCKED_BASH_PATTERNS) {
+    if (pattern.test(command)) {
+      return {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: `Blocked: command matches dangerous pattern (${pattern.source}). Symphony agents cannot restart or destroy host processes.`,
+        },
+      };
+    }
+  }
+  return { continue: true };
+}
+
+export class ClaudeCodeSession {
+  private readonly sessionId: string;
+  private abortController: AbortController | null = null;
+  private stopped = false;
+
+  constructor(
+    private readonly config: SymphonyConfig,
+    private readonly workspacePath: string,
+    private readonly issue: Issue,
+    private readonly dynamicTools: DynamicToolHandler,
+    private readonly onUpdate?: (update: AppServerUpdate) => void,
+  ) {
+    this.sessionId = `claude-${issue.identifier}-${Date.now()}`;
+  }
+
+  async start(): Promise<AppServerSessionMeta> {
+    return { threadId: this.sessionId };
+  }
+
+  async runTurn(prompt: string): Promise<AppServerTurnResult> {
+    const turnId = `${this.sessionId}-turn-${Date.now()}`;
+    this.abortController = new AbortController();
+    this.stopped = false;
+
+    const toolList = this.dynamicTools.listTools();
+    const mcpTools = toolList.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: buildZodShape(tool.inputSchema as Record<string, unknown>),
+      handler: async (args: Record<string, unknown>) => {
+        try {
+          const result = await this.dynamicTools.execute(tool.name, args);
+          const text = typeof result === "string" ? result : JSON.stringify(result);
+          return { content: [{ type: "text" as const, text }] };
+        } catch (err: any) {
+          appendIssueLog(this.issue.identifier, `[claude-tool-error] ${tool.name}: ${err.message}`);
+          return { content: [{ type: "text" as const, text: `Error: ${err.message}` }], isError: true };
+        }
+      },
+    }));
+
+    const toolServer = mcpTools.length > 0
+      ? createSdkMcpServer({ name: MCP_SERVER_NAME, tools: mcpTools })
+      : null;
+
+    const cc = this.config.claudeCode;
+    let lastAgentMessage: string | null = null;
+
+    try {
+      const conversation = query({
+        prompt,
+        options: {
+          model: cc.model,
+          cwd: this.workspacePath,
+          tools: { type: "preset", preset: "claude_code" },
+          allowedTools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebSearch", "WebFetch"],
+          ...(toolServer ? { mcpServers: { [MCP_SERVER_NAME]: toolServer } } : {}),
+          ...(cc.maxTurnsPerQuery !== null ? { maxTurns: cc.maxTurnsPerQuery } : {}),
+          ...(cc.systemPromptAppend
+            ? {
+                systemPrompt: {
+                  type: "preset" as const,
+                  preset: "claude_code" as const,
+                  append: cc.systemPromptAppend,
+                },
+              }
+            : {}),
+          abortController: this.abortController,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } as any);
+
+      for await (const message of conversation) {
+        if (this.stopped) break;
+
+        if (message.type === "assistant") {
+          for (const block of message.message.content) {
+            if (block.type === "text" && block.text) {
+              lastAgentMessage = block.text;
+              this.onUpdate?.({
+                type: "item/agentMessage/delta",
+                threadId: this.sessionId,
+                turnId,
+                text: block.text,
+              });
+            }
+          }
+        }
+
+        if (message.type === "result") {
+          const result = message as any;
+          if (result.subtype === "success" && result.result) {
+            lastAgentMessage = result.result as string;
+          }
+          appendIssueLog(
+            this.issue.identifier,
+            `[claude-turn] subtype=${result.subtype} turns=${result.num_turns ?? "?"}`,
+          );
+          this.onUpdate?.({
+            type: "turn.completed",
+            threadId: this.sessionId,
+            turnId,
+            text: lastAgentMessage ?? undefined,
+          });
+        }
+      }
+    } catch (err: any) {
+      if (this.stopped || err.name === "AbortError") {
+        throw err;
+      }
+      appendIssueLog(this.issue.identifier, `[claude-session-error] ${err.message}`);
+      throw err;
+    }
+
+    return { turnId, lastAgentMessage };
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.abortController?.abort();
+  }
+
+  forceKill(): void {
+    this.stop();
+  }
+}

--- a/src/symphony/config.ts
+++ b/src/symphony/config.ts
@@ -2,7 +2,7 @@ import * as os from "os";
 import * as path from "path";
 import { resolveCodexBinary } from "../codex.js";
 import { SYMPHONY_HOME } from "./paths.js";
-import type { CodexApprovalPolicy, SymphonyConfig, WorkflowDefinition } from "./types.js";
+import type { ClaudeCodeConfig, CodexApprovalPolicy, SymphonyConfig, WorkflowDefinition } from "./types.js";
 
 const DEFAULT_ACTIVE_STATES = ["Todo", "In Progress"];
 const DEFAULT_TERMINAL_STATES = ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"];
@@ -65,6 +65,10 @@ function approvalPolicyValue(value: unknown): CodexApprovalPolicy {
   };
 }
 
+function agentProviderValue(value: string | null): SymphonyConfig["agent"]["provider"] {
+  return value?.trim().toLowerCase() === "claude-code" ? "claude-code" : "codex";
+}
+
 export function buildSymphonyConfig(definition: WorkflowDefinition): SymphonyConfig {
   const tracker = section(definition.config, "tracker");
   const polling = section(definition.config, "polling");
@@ -73,6 +77,7 @@ export function buildSymphonyConfig(definition: WorkflowDefinition): SymphonyCon
   const hooks = section(definition.config, "hooks");
   const agent = section(definition.config, "agent");
   const codex = section(definition.config, "codex");
+  const claudeCode = section(definition.config, "claude_code");
   const server = section(definition.config, "server");
 
   const resolvedConfig: SymphonyConfig = {
@@ -129,6 +134,7 @@ export function buildSymphonyConfig(definition: WorkflowDefinition): SymphonyCon
       maxConcurrentAgents: intValue(agent.max_concurrent_agents, 2),
       maxTurns: intValue(agent.max_turns, 20),
       maxRetryBackoffMs: intValue(agent.max_retry_backoff_ms, 300_000),
+      provider: agentProviderValue(stringValue(agent.provider)),
     },
     codex: {
       command: stringValue(codex.command) || `${resolveCodexBinary() || "codex"} app-server`,
@@ -141,6 +147,7 @@ export function buildSymphonyConfig(definition: WorkflowDefinition): SymphonyCon
       stallTimeoutMs: intValue(codex.stall_timeout_ms, 300_000),
       serviceName: stringValue(codex.service_name) || "chris-assistant-symphony",
     },
+    claudeCode: buildClaudeCodeConfig(claudeCode),
     server: {
       host: stringValue(server.host) || "127.0.0.1",
       port: typeof server.port === "number" ? Math.trunc(server.port) : 3010,
@@ -149,6 +156,15 @@ export function buildSymphonyConfig(definition: WorkflowDefinition): SymphonyCon
 
   validateSymphonyConfig(resolvedConfig);
   return resolvedConfig;
+}
+
+function buildClaudeCodeConfig(raw: Record<string, unknown>): ClaudeCodeConfig {
+  return {
+    model: stringValue(raw.model) || process.env.AI_MODEL || "claude-sonnet-4-6",
+    maxTurnsPerQuery: typeof raw.max_turns_per_query === "number" ? Math.trunc(raw.max_turns_per_query) : null,
+    systemPromptAppend: stringValue(raw.system_prompt_append),
+    turnTimeoutMs: intValue(raw.turn_timeout_ms, 3_600_000),
+  };
 }
 
 export function buildTurnSandboxPolicy(config: SymphonyConfig, workspacePath: string): Record<string, unknown> {
@@ -186,11 +202,11 @@ export function validateSymphonyConfig(config: SymphonyConfig): void {
     throw new Error("landing.enabled currently requires tracker.kind: github");
   }
 
-  if (config.landing.enabled && !config.landing.branchPrefix.startsWith("codex/")) {
-    throw new Error("landing.branch_prefix must start with codex/");
+  if (config.landing.enabled && config.agent.provider === "codex" && !config.landing.branchPrefix.startsWith("codex/")) {
+    throw new Error("landing.branch_prefix must start with codex/ when using the codex provider");
   }
 
-  if (!config.codex.command.trim()) {
+  if (config.agent.provider === "codex" && !config.codex.command.trim()) {
     throw new Error("Missing codex.command in WORKFLOW.md");
   }
 }

--- a/src/symphony/types.ts
+++ b/src/symphony/types.ts
@@ -36,6 +36,13 @@ export type CodexApprovalPolicy =
 
 export type CodexThreadSandbox = "read-only" | "workspace-write" | "danger-full-access";
 
+export interface ClaudeCodeConfig {
+  model: string;
+  maxTurnsPerQuery: number | null;
+  systemPromptAppend: string | null;
+  turnTimeoutMs: number;
+}
+
 export interface SymphonyConfig {
   workflowPath: string;
   tracker: {
@@ -77,6 +84,7 @@ export interface SymphonyConfig {
     maxConcurrentAgents: number;
     maxTurns: number;
     maxRetryBackoffMs: number;
+    provider: "codex" | "claude-code";
   };
   codex: {
     command: string;
@@ -89,6 +97,7 @@ export interface SymphonyConfig {
     stallTimeoutMs: number;
     serviceName: string | null;
   };
+  claudeCode: ClaudeCodeConfig;
   server: {
     host: string;
     port: number | null;

--- a/tests/symphony-app-server.test.ts
+++ b/tests/symphony-app-server.test.ts
@@ -105,7 +105,7 @@ function makeConfig(command: string, workspaceRoot: string): SymphonyConfig {
       beforeRemove: null,
       timeoutMs: 10_000,
     },
-    agent: { maxConcurrentAgents: 1, maxTurns: 1, maxRetryBackoffMs: 10_000 },
+    agent: { maxConcurrentAgents: 1, maxTurns: 1, maxRetryBackoffMs: 10_000, provider: "codex" as const },
     codex: {
       command,
       model: null,
@@ -116,6 +116,12 @@ function makeConfig(command: string, workspaceRoot: string): SymphonyConfig {
       readTimeoutMs: 5_000,
       stallTimeoutMs: 5_000,
       serviceName: "test-symphony",
+    },
+    claudeCode: {
+      model: "claude-sonnet-4-6",
+      maxTurnsPerQuery: null,
+      systemPromptAppend: null,
+      turnTimeoutMs: 3_600_000,
     },
     server: { host: "127.0.0.1", port: null },
   };

--- a/tests/symphony-github-tracker.test.ts
+++ b/tests/symphony-github-tracker.test.ts
@@ -40,6 +40,7 @@ function makeConfig(): SymphonyConfig {
       maxConcurrentAgents: 1,
       maxTurns: 1,
       maxRetryBackoffMs: 10_000,
+      provider: "codex" as const,
     },
     codex: {
       command: "codex app-server",
@@ -51,6 +52,12 @@ function makeConfig(): SymphonyConfig {
       readTimeoutMs: 5_000,
       stallTimeoutMs: 5_000,
       serviceName: "test",
+    },
+    claudeCode: {
+      model: "claude-sonnet-4-6",
+      maxTurnsPerQuery: null,
+      systemPromptAppend: null,
+      turnTimeoutMs: 3_600_000,
     },
     server: {
       host: "127.0.0.1",

--- a/tests/symphony-landing.test.ts
+++ b/tests/symphony-landing.test.ts
@@ -44,6 +44,7 @@ function makeConfig(root: string): SymphonyConfig {
       maxConcurrentAgents: 1,
       maxTurns: 1,
       maxRetryBackoffMs: 10_000,
+      provider: "codex" as const,
     },
     codex: {
       command: "codex app-server",
@@ -55,6 +56,12 @@ function makeConfig(root: string): SymphonyConfig {
       readTimeoutMs: 5_000,
       stallTimeoutMs: 5_000,
       serviceName: "test",
+    },
+    claudeCode: {
+      model: "claude-sonnet-4-6",
+      maxTurnsPerQuery: null,
+      systemPromptAppend: null,
+      turnTimeoutMs: 3_600_000,
     },
     server: {
       host: "127.0.0.1",

--- a/tests/symphony-orchestrator.test.ts
+++ b/tests/symphony-orchestrator.test.ts
@@ -54,7 +54,7 @@ function makeConfig(workspaceRoot: string): SymphonyConfig {
       beforeRemove: null,
       timeoutMs: 10_000,
     },
-    agent: { maxConcurrentAgents: 0, maxTurns: 1, maxRetryBackoffMs: 10_000 },
+    agent: { maxConcurrentAgents: 0, maxTurns: 1, maxRetryBackoffMs: 10_000, provider: "codex" as const },
     codex: {
       command: "codex app-server",
       model: null,
@@ -65,6 +65,12 @@ function makeConfig(workspaceRoot: string): SymphonyConfig {
       readTimeoutMs: 5_000,
       stallTimeoutMs: 5_000,
       serviceName: "test-symphony",
+    },
+    claudeCode: {
+      model: "claude-sonnet-4-6",
+      maxTurnsPerQuery: null,
+      systemPromptAppend: null,
+      turnTimeoutMs: 3_600_000,
     },
     server: { host: "127.0.0.1", port: null },
   };

--- a/tests/symphony-workspace.test.ts
+++ b/tests/symphony-workspace.test.ts
@@ -45,6 +45,7 @@ function makeConfig(root: string): SymphonyConfig {
       maxConcurrentAgents: 1,
       maxTurns: 1,
       maxRetryBackoffMs: 10_000,
+      provider: "codex" as const,
     },
     codex: {
       command: "codex app-server",
@@ -56,6 +57,12 @@ function makeConfig(root: string): SymphonyConfig {
       readTimeoutMs: 5_000,
       stallTimeoutMs: 5_000,
       serviceName: "test",
+    },
+    claudeCode: {
+      model: "claude-sonnet-4-6",
+      maxTurnsPerQuery: null,
+      systemPromptAppend: null,
+      turnTimeoutMs: 3_600_000,
     },
     server: {
       host: "127.0.0.1",


### PR DESCRIPTION
## Summary
- Adds `agent.provider` config (defaults to `codex`, opt-in `claude-code`) selecting between Codex and Claude Code session backends in Symphony
- New `ClaudeCodeSession` uses `@anthropic-ai/claude-agent-sdk`'s `query` + `createSdkMcpServer` for dynamic tools, with a `PreToolUse` hook blocking destructive bash patterns (pm2, kill chris-assistant, systemctl restart, reboot, shutdown, rm -rf /~)
- `agent-runner.ts` introduces an `AgentSession` interface and `createSession()` factory; both backends implement `start`/`runTurn`/`stop`/`forceKill`
- Symphony config validation relaxes codex-only fields when `provider: claude-code`
- `WORKFLOW.md` documents the new `claude_code` config block

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (217 tests)
- [ ] Smoke-test a workflow with `agent.provider: claude-code` end-to-end before merging