### PR TITLE
chore: ignore local Claude tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/
 *.log
 .DS_Store
 .claude/worktrees/
+.claude/scheduled_tasks.lock
+.claude/skills/wiki-ingest/
+.memsearch/
 .codex/
 docs/.vitepress/cache
 docs/.vitepress/dist


### PR DESCRIPTION
## Summary
- Ignore `.claude/scheduled_tasks.lock`, `.claude/skills/wiki-ingest/` (personal Obsidian skill, not project code), and `.memsearch/` so they stop appearing as untracked in `git status`.

## Test plan
- [x] `git status` is clean on main after pulling