### PR TITLE
recovery: restore assistant identity contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Switch between providers with a single command. The model string determines the 
 | Provider | Models | Auth |
 |----------|--------|------|
 | **Claude Agent** | Opus, Sonnet, Haiku | Claude CLI (`claude` — uses your Max subscription) |
-| **OpenAI Responses** | GPT-5.x, GPT-4o, o3, o4-mini | ChatGPT Plus/Pro subscription (OAuth) |
+| **OpenAI Responses** | GPT-5.5, GPT-5.4, GPT-5.3 Codex, GPT-4o | ChatGPT Plus/Pro subscription (OAuth) |
 | **OpenAI Codex Agent** | `codex-agent-*` models | Codex CLI (`codex login`) |
-| **MiniMax** | M2.5, M2.5-highspeed | MiniMax subscription (OAuth) |
+| **MiniMax** | M2.7, M2.7-highspeed, M2.5 | MiniMax subscription (OAuth) |
 
 Claude uses the [Agent SDK](https://github.com/anthropics/claude-agent-sdk), which piggybacks on the Claude CLI's authentication — just run `claude` once to log in, and the bot picks it up automatically.
 
@@ -61,7 +61,7 @@ The Codex agent mode uses `@openai/codex-sdk`, which spawns the `codex` CLI unde
 
 ```bash
 chris model set sonnet         # Switch to Claude Sonnet
-chris model set gpt5           # Switch to OpenAI GPT-5.2
+chris model set gpt5           # Switch to OpenAI GPT-5.5
 chris model set codex-agent    # Switch to OpenAI Codex Agent
 chris model set minimax        # Switch to MiniMax
 ```
@@ -210,6 +210,7 @@ chris openai login / status      # OpenAI OAuth
 chris minimax login / status     # MiniMax OAuth
 
 # Diagnostics
+chris prompt inspect            # Redacted prompt section diagnostics
 chris doctor                     # Health checks
 chris doctor --fix               # Auto-diagnose and repair
 chris setup                      # First-time setup wizard

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -32,18 +32,28 @@ chris model search <q>   # Filter models by name, provider, or description
 
 | Shortcut | Model ID | Provider |
 |----------|----------|----------|
-| `opus` | claude-opus-4-6 | Claude |
+| `opus` | claude-opus-4-7 | Claude |
 | `sonnet` | claude-sonnet-4-6 | Claude |
 | `haiku` | claude-haiku-4-5-20251001 | Claude |
+| `opus-4-6` | claude-opus-4-6 | Claude |
 | `sonnet-4-5` | claude-sonnet-4-5-20250929 | Claude |
-| `gpt5` | gpt-5.2 | OpenAI |
-| `codex` | GPT-5.3-Codex | OpenAI |
+| `gpt5` | gpt-5.5 | OpenAI |
+| `gpt54` | gpt-5.4 | OpenAI |
+| `gpt54-mini` | gpt-5.4-mini | OpenAI |
+| `gpt54-nano` | gpt-5.4-nano | OpenAI |
+| `codex` | gpt-5.3-codex | OpenAI |
+| `codex-spark` | gpt-5.3-codex-spark | OpenAI |
+| `codex-agent` | codex-agent-gpt-5.5 | OpenAI Codex Agent |
+| `codex-agent-fast` | codex-agent-gpt-5.4-mini | OpenAI Codex Agent |
+| `codex-agent-coding` | codex-agent-gpt-5.3-codex | OpenAI Codex Agent |
+| `gpt52` | gpt-5.2 | OpenAI |
 | `gpt4o` | gpt-4o | OpenAI |
 | `gpt41` | gpt-4.1 | OpenAI |
 | `o3` | o3 | OpenAI |
 | `o4-mini` | o4-mini | OpenAI |
-| `minimax` | MiniMax-M2.5 | MiniMax |
-| `minimax-fast` | MiniMax-M2.5-highspeed | MiniMax |
+| `minimax` | MiniMax-M2.7 | MiniMax |
+| `minimax-fast` | MiniMax-M2.7-highspeed | MiniMax |
+| `minimax-m25` | MiniMax-M2.5 | MiniMax |
 
 ## Memory Management
 
@@ -84,6 +94,8 @@ chris minimax status     # Check OAuth token status and expiry
 ## Diagnostics
 
 ```bash
+chris prompt inspect     # Show redacted prompt sections, provider, workspace, and memory-section status
+
 chris doctor             # Run all health checks:
                          #   - .env file exists
                          #   - Required env vars are set
@@ -132,6 +144,6 @@ chris symphony cleanup --delete-remote-branches --apply  # Also prune stale remo
 ## Codex
 
 ```bash
-chris codex verify       # Check that the codex CLI is installed and working
-chris codex login        # Authenticate with OpenAI (required for codex-agent-* models)
+chris codex status       # Show Codex CLI binary/auth/app-server status
+chris codex doctor       # Run Codex CLI readiness checks
 ```

--- a/src/cli/commands/model.ts
+++ b/src/cli/commands/model.ts
@@ -12,23 +12,32 @@ const DEFAULT_MODEL = "gpt-4o";
 /** Well-known model IDs for quick reference */
 const KNOWN_MODELS: Record<string, { id: string; provider: string }> = {
   // Claude
-  "opus": { id: "claude-opus-4-6", provider: "claude" },
+  "opus": { id: "claude-opus-4-7", provider: "claude" },
   "sonnet": { id: "claude-sonnet-4-6", provider: "claude" },
   "haiku": { id: "claude-haiku-4-5-20251001", provider: "claude" },
+  "opus-4-6": { id: "claude-opus-4-6", provider: "claude" },
   "sonnet-4-5": { id: "claude-sonnet-4-5-20250929", provider: "claude" },
-  // OpenAI — current flagship
-  "gpt5": { id: "gpt-5.2", provider: "openai" },
-  "codex": { id: "GPT-5.3-Codex", provider: "openai" },
-  "codex-agent": { id: "codex-agent-o4-mini", provider: "codex-agent" },
-  "codex-agent-o3": { id: "codex-agent-o3", provider: "codex-agent" },
+  // OpenAI — current recommended models
+  "gpt5": { id: "gpt-5.5", provider: "openai" },
+  "gpt54": { id: "gpt-5.4", provider: "openai" },
+  "gpt54-mini": { id: "gpt-5.4-mini", provider: "openai" },
+  "gpt54-nano": { id: "gpt-5.4-nano", provider: "openai" },
+  "codex": { id: "gpt-5.3-codex", provider: "openai" },
+  "codex-spark": { id: "gpt-5.3-codex-spark", provider: "openai" },
+  "codex-agent": { id: "codex-agent-gpt-5.5", provider: "codex-agent" },
+  "codex-agent-fast": { id: "codex-agent-gpt-5.4-mini", provider: "codex-agent" },
+  "codex-agent-coding": { id: "codex-agent-gpt-5.3-codex", provider: "codex-agent" },
+  // OpenAI — older reasoning models still accepted
   "o3": { id: "o3", provider: "openai" },
   "o4-mini": { id: "o4-mini", provider: "openai" },
   // OpenAI — previous gen
+  "gpt52": { id: "gpt-5.2", provider: "openai" },
   "gpt4o": { id: "gpt-4o", provider: "openai" },
   "gpt41": { id: "gpt-4.1", provider: "openai" },
   // MiniMax
-  "minimax": { id: "MiniMax-M2.5", provider: "minimax" },
-  "minimax-fast": { id: "MiniMax-M2.5-highspeed", provider: "minimax" },
+  "minimax": { id: "MiniMax-M2.7", provider: "minimax" },
+  "minimax-fast": { id: "MiniMax-M2.7-highspeed", provider: "minimax" },
+  "minimax-m25": { id: "MiniMax-M2.5", provider: "minimax" },
 };
 
 function getCurrentModel(): string {
@@ -86,7 +95,7 @@ export function registerModelCommand(program: Command) {
       console.log("Shortcuts:");
       for (const [alias, info] of Object.entries(KNOWN_MODELS)) {
         const marker = info.id === current ? " ← active" : "";
-        console.log("  %s %s %s%s", alias.padEnd(14), info.provider.padEnd(8), info.id, marker);
+        console.log("  %s %s %s%s", alias.padEnd(20), info.provider.padEnd(12), info.id, marker);
       }
       console.log("");
       console.log('Change with: chris model set <name-or-id>');
@@ -107,35 +116,44 @@ export function registerModelCommand(program: Command) {
   /** All known models across providers for search */
   const ALL_MODELS: { id: string; provider: string; description: string }[] = [
     // Claude
-    { id: "claude-opus-4-6", provider: "claude", description: "Most capable Claude model" },
-    { id: "claude-sonnet-4-6", provider: "claude", description: "Balanced Claude model" },
+    { id: "claude-opus-4-7", provider: "claude", description: "Most capable Claude model for complex reasoning and agentic coding" },
+    { id: "claude-sonnet-4-6", provider: "claude", description: "Best Claude speed/intelligence balance" },
+    { id: "claude-opus-4-6", provider: "claude", description: "Previous Opus generation" },
     { id: "claude-sonnet-4-5-20250929", provider: "claude", description: "Previous-gen Sonnet" },
     { id: "claude-haiku-4-5-20251001", provider: "claude", description: "Fast, lightweight Claude" },
-    // OpenAI — GPT-5 series (current flagship)
-    { id: "gpt-5.2", provider: "openai", description: "Current flagship, professional knowledge work" },
-    { id: "gpt-5.2-chat-latest", provider: "openai", description: "Instant version of GPT-5.2" },
-    { id: "gpt-5.2-pro", provider: "openai", description: "More compute for harder reasoning" },
-    { id: "GPT-5.3-Codex", provider: "openai", description: "Most advanced agentic coding model" },
-    { id: "GPT-5.2-Codex", provider: "openai", description: "Previous Codex coding model" },
-    { id: "GPT-5.1-Codex-Mini", provider: "openai", description: "Smaller, cost-effective Codex" },
-    { id: "codex-agent-o4-mini", provider: "codex-agent", description: "Codex SDK agent provider on o4-mini" },
-    { id: "codex-agent-o3", provider: "codex-agent", description: "Codex SDK agent provider on o3" },
+    // OpenAI — GPT-5 series (current recommended)
+    { id: "gpt-5.5", provider: "openai", description: "Current flagship for complex reasoning, coding, and professional work" },
+    { id: "gpt-5.4", provider: "openai", description: "Affordable frontier model for coding and professional work" },
+    { id: "gpt-5.4-mini", provider: "openai", description: "Strong mini model for coding, computer use, and subagents" },
+    { id: "gpt-5.4-nano", provider: "openai", description: "Fastest, lowest-cost GPT-5.4 variant" },
+    { id: "gpt-5.3-codex", provider: "openai", description: "Specialized coding model for complex software engineering" },
+    { id: "gpt-5.3-codex-spark", provider: "openai", description: "Research preview for near-instant coding iteration" },
+    { id: "gpt-5.2", provider: "openai", description: "Previous general-purpose model" },
+    { id: "gpt-5.2-chat-latest", provider: "openai", description: "Previous ChatGPT-style GPT-5.2 model" },
+    { id: "gpt-5.2-pro", provider: "openai", description: "Previous higher-compute GPT-5.2 model" },
+    { id: "codex-agent-gpt-5.5", provider: "codex-agent", description: "Codex SDK agent provider on gpt-5.5" },
+    { id: "codex-agent-gpt-5.4", provider: "codex-agent", description: "Codex SDK agent provider on gpt-5.4" },
+    { id: "codex-agent-gpt-5.4-mini", provider: "codex-agent", description: "Codex SDK agent provider on gpt-5.4-mini" },
+    { id: "codex-agent-gpt-5.3-codex", provider: "codex-agent", description: "Codex SDK agent provider on gpt-5.3-codex" },
+    { id: "codex-agent-gpt-5.3-codex-spark", provider: "codex-agent", description: "Codex SDK agent provider on codex spark preview" },
     // OpenAI — o-series (reasoning)
-    { id: "o3", provider: "openai", description: "Powerful reasoning (math, science, code)" },
-    { id: "o3-mini", provider: "openai", description: "Lightweight reasoning" },
-    { id: "o3-pro", provider: "openai", description: "Enhanced reasoning, more compute" },
+    { id: "o3", provider: "openai", description: "Older powerful reasoning model" },
+    { id: "o3-mini", provider: "openai", description: "Older lightweight reasoning model" },
+    { id: "o3-pro", provider: "openai", description: "Older enhanced reasoning model" },
     { id: "o3-deep-research", provider: "openai", description: "Deep research variant of o3" },
-    { id: "o4-mini", provider: "openai", description: "Fast reasoning model" },
+    { id: "o4-mini", provider: "openai", description: "Older fast reasoning model" },
     { id: "o4-mini-deep-research", provider: "openai", description: "Deep research variant of o4-mini" },
     // OpenAI — GPT-4 series (previous gen)
-    { id: "gpt-4o", provider: "openai", description: "Versatile flagship (text + vision)" },
+    { id: "gpt-4o", provider: "openai", description: "Previous versatile GPT-4o model" },
     { id: "gpt-4o-mini", provider: "openai", description: "Small, fast, affordable" },
-    { id: "gpt-4.1", provider: "openai", description: "Coding-optimized, 1M context" },
-    { id: "gpt-4.1-mini", provider: "openai", description: "Smaller coding model" },
-    { id: "gpt-4.1-nano", provider: "openai", description: "Fastest coding model" },
+    { id: "gpt-4.1", provider: "openai", description: "Previous non-reasoning coding model" },
+    { id: "gpt-4.1-mini", provider: "openai", description: "Previous smaller GPT-4.1 model" },
+    { id: "gpt-4.1-nano", provider: "openai", description: "Previous fastest GPT-4.1 model" },
     // MiniMax
-    { id: "MiniMax-M2.5", provider: "minimax", description: "MiniMax flagship" },
-    { id: "MiniMax-M2.5-highspeed", provider: "minimax", description: "MiniMax fast mode" },
+    { id: "MiniMax-M2.7", provider: "minimax", description: "Current MiniMax text generation model" },
+    { id: "MiniMax-M2.7-highspeed", provider: "minimax", description: "Current MiniMax high-speed mode" },
+    { id: "MiniMax-M2.5", provider: "minimax", description: "Previous MiniMax agentic model" },
+    { id: "MiniMax-M2.5-highspeed", provider: "minimax", description: "Previous MiniMax fast mode" },
   ];
 
   model

--- a/src/cli/commands/prompt.ts
+++ b/src/cli/commands/prompt.ts
@@ -1,0 +1,15 @@
+import { Command } from "commander";
+import { inspectPrompt } from "../../providers/shared.js";
+
+export function registerPromptCommand(program: Command): void {
+  const prompt = program
+    .command("prompt")
+    .description("Inspect assistant prompt assembly");
+
+  prompt
+    .command("inspect")
+    .description("Show redacted prompt sections and runtime metadata")
+    .action(async () => {
+      console.log(await inspectPrompt());
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { registerOpenaiCommand } from "./commands/openai-login.js";
 import { registerCodexCommand } from "./commands/codex.js";
 import { registerDreamCommand } from "./commands/dream.js";
 import { registerSymphonyCommand } from "./commands/symphony.js";
+import { registerPromptCommand } from "./commands/prompt.js";
 
 const program = new Command();
 
@@ -41,6 +42,7 @@ registerDoctorCommand(program);
 registerSetupCommand(program);
 registerCodexCommand(program);
 registerSymphonyCommand(program);
+registerPromptCommand(program);
 
 // Memory consolidation
 registerDreamCommand(program);

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { loadMemory, buildSystemPrompt } from "../memory/loader.js";
+import type { LoadedMemory } from "../memory/loader.js";
 import { config } from "../config.js";
 import { resetLoopDetection } from "../tools/index.js";
 import { getWorkspaceRoot, isProjectActive, setWorkspaceChangeCallback } from "../tools/files.js";
@@ -39,6 +40,218 @@ function loadBootstrapFile(): string | null {
     }
   }
   return null;
+}
+
+type PromptProviderMode = "openai" | "claude" | "codex-agent";
+
+interface PromptAssembly {
+  assistantRuntimeContract: string;
+  identityMemory: string;
+  runtimeContext: string;
+  providerAdapter: string;
+  formatting: string;
+  projectContext: string;
+}
+
+export interface PromptInspectionSection {
+  name: string;
+  present: boolean;
+  chars: number;
+  details?: string[];
+}
+
+export interface PromptInspection {
+  model: string;
+  provider: string;
+  workspaceRoot: string;
+  sections: PromptInspectionSection[];
+}
+
+function currentDateTimeSection(): string {
+  const now = new Date();
+  const dateStr = now.toLocaleDateString("en-GB", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "Europe/London",
+  });
+  const timeStr = now.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Europe/London",
+  });
+
+  return `# Current Date & Time
+
+Today is **${dateStr}** and the current time is **${timeStr} (Europe/London)**. Use this when answering any question about today's date, the day of the week, upcoming events, or scheduling. Do not rely on training data for the current date.`;
+}
+
+export function buildAssistantRuntimeContract(): string {
+  return `# Assistant Runtime Contract
+
+You are **Chris Assistant**: Chris's personal assistant with memory, purpose, continuity, and local runtime awareness. You are not Claude Code, not the Codex CLI, not a generic OpenAI assistant, and not a provider-branded coding shell.
+
+## Identity Answers
+
+- If Chris asks "who are you?", answer that you are Chris Assistant.
+- If Chris asks "where do you run?", explain that you run as the \`chris-assistant\` Node.js/TypeScript app, normally reached through Telegram, on Chris's MacBook Pro under pm2.
+- If Chris asks "what memory/tools do you have?", describe persistent memory, recent conversation summaries, journal context, reusable skills, and the provider-specific tools available in the current mode.
+- If Chris asks "how are you different from Claude Code?", explain that Claude Code or Codex may be execution substrates, but Chris Assistant is the product identity, memory layer, Telegram surface, tool policy, and continuity contract.
+
+## Operating Contract
+
+- Preserve the feeling of a personal assistant first. Use coding-agent abilities when useful, but do not let tool/runtime branding replace your identity.
+- Treat memory, journal notes, and recent summaries as part of your continuity with Chris.
+- Be explicit about the active model or provider if asked, while still identifying as Chris Assistant.`;
+}
+
+function buildIdentityMemorySection(memory: LoadedMemory): string {
+  const body = buildSystemPrompt(memory);
+  return body ? `# Identity / Memory\n\n${body}` : "";
+}
+
+function buildRuntimeContextSection(model: string, provider: string): string {
+  return `# Runtime Context
+
+You are currently running as model \`${model}\` through ${provider}. If asked what model or provider you are using, report that accurately without adopting the provider as your identity.
+
+## Where You Live
+
+You are the \`chris-assistant\` project. You run as a Node.js process managed by pm2 on **Chris's MacBook Pro** (the local machine, not a remote server).
+
+- **Your source code**: \`${PROJECT_ROOT}/\`
+- **Your config/data**: \`~/.chris-assistant/\`
+- **Your logs**: read \`~/.pm2/logs/chris-assistant-out.log\` and \`~/.pm2/logs/chris-assistant-error.log\` directly
+- **Your schedules**: \`~/.chris-assistant/schedules.json\`
+- **Your process**: managed by pm2; \`npx pm2 list\` shows status
+
+When debugging your own errors, inspect local logs and source code first. Never SSH to debug yourself; SSH is for remote devices on Tailscale, not for inspecting your own process.`;
+}
+
+function buildProviderAdapterSection(mode: PromptProviderMode): string {
+  if (mode === "claude") {
+    return `# Provider Adapter
+
+You are running through the Anthropic Claude Agent SDK with the Claude Code tool preset. Claude Code is an execution substrate and tool runtime, not your identity.
+
+- Do not introduce yourself as Claude Code or a Claude Code CLI session.
+- Use native Claude Code tools for repository work when they help.
+- Use Chris Assistant custom MCP tools for memory, journal, recall, schedules, skills, SSH, macOS helpers, browser tools, market data, energy data, usage reports, and other assistant capabilities.
+- If the Claude Code preset says something generic about identity, this Chris Assistant runtime contract takes priority.`;
+  }
+
+  if (mode === "codex-agent") {
+    return `# Provider Adapter
+
+You are running through the OpenAI Codex SDK, which wraps the local \`codex\` CLI. Codex is an execution substrate and coding runtime, not your identity.
+
+- Do not introduce yourself as Codex, the Codex CLI, or a generic coding agent.
+- Use Codex native coding abilities for repository work when they help.
+- Stay grounded in Chris Assistant's memory, Telegram surface, and local runtime context.
+- Ask before destructive or wide-ranging changes.`;
+  }
+
+  return `# Provider Adapter
+
+You are running through the OpenAI-backed tool-calling provider in \`chris-assistant\`. The API/model is an execution substrate, not your identity.
+
+- Use your registered tools directly when they genuinely help.
+- For coding work, read first, understand the repo, then make focused changes.
+- For normal conversation, answer naturally as Chris Assistant without unnecessary tool use.`;
+}
+
+function buildFormattingSection(): string {
+  return `# Formatting
+
+Every response is rendered in Telegram.
+
+1. Use emoji as visual markers when they improve scanability.
+2. Bold key terms, options, names, and decisions.
+3. Use line breaks generously; never send dense walls of text.
+4. Keep short replies warm and human.
+5. Do not dump raw tool chatter back to Chris.`;
+}
+
+function buildProjectContextSection(bootstrap: string | null): string {
+  return bootstrap
+    ? `# Project Context\n\nThe following is from the active project's documentation:\n\n${bootstrap}`
+    : "";
+}
+
+function assemblePromptSections(memory: LoadedMemory, mode: PromptProviderMode, bootstrap: string | null): PromptAssembly {
+  const model = config.model;
+  const provider = getProviderName(model);
+  return {
+    assistantRuntimeContract: buildAssistantRuntimeContract(),
+    identityMemory: buildIdentityMemorySection(memory),
+    runtimeContext: buildRuntimeContextSection(model, provider),
+    providerAdapter: buildProviderAdapterSection(mode),
+    formatting: buildFormattingSection(),
+    projectContext: buildProjectContextSection(bootstrap),
+  };
+}
+
+function joinPromptSections(sections: Array<string | null | undefined>): string {
+  return sections.filter((section): section is string => !!section && section.trim().length > 0).join("\n\n---\n\n");
+}
+
+export function buildPromptInspectionReport(inspection: PromptInspection): string {
+  const lines = [
+    "Chris Assistant Prompt Inspection",
+    "",
+    `Active model: ${inspection.model}`,
+    `Resolved provider: ${inspection.provider}`,
+    `Workspace root: ${inspection.workspaceRoot}`,
+    "",
+    "Sections:",
+  ];
+
+  for (const section of inspection.sections) {
+    const status = section.present ? "present" : "missing";
+    lines.push(`- ${section.name}: ${status}, ~${section.chars} chars`);
+    for (const detail of section.details ?? []) {
+      lines.push(`  ${detail}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("Raw memory bodies, tokens, and environment values are intentionally redacted.");
+  return lines.join("\n");
+}
+
+export async function inspectPrompt(): Promise<string> {
+  const memory = await loadMemory();
+  const bootstrap = loadBootstrapFile();
+  const mode = config.model.toLowerCase().startsWith("codex-agent")
+    ? "codex-agent"
+    : config.model.toLowerCase().startsWith("claude-")
+      ? "claude"
+      : "openai";
+  const sections = assemblePromptSections(memory, mode, bootstrap);
+  const memoryDetails = [
+    `identity: ${memory.identity ? "present" : "missing"}`,
+    `curatedSummary: ${memory.curatedSummary ? "present" : "missing"}`,
+    `knowledge: ${memory.knowledge ? "present" : "missing"}`,
+    `memory: ${memory.memory ? "present" : "missing"}`,
+    `recentSummaries: ${memory.recentSummaries ? "present" : "missing"}`,
+    `recentJournal: ${memory.recentJournal ? "present" : "missing"}`,
+    `skillIndex: ${memory.skillIndex ? "present" : "missing"}`,
+  ];
+
+  return buildPromptInspectionReport({
+    model: config.model,
+    provider: getProviderName(config.model),
+    workspaceRoot: getWorkspaceRoot(),
+    sections: [
+      { name: "Assistant Runtime Contract", present: true, chars: sections.assistantRuntimeContract.length },
+      { name: "Identity / Memory", present: !!sections.identityMemory, chars: sections.identityMemory.length, details: memoryDetails },
+      { name: "Runtime Context", present: true, chars: sections.runtimeContext.length },
+      { name: "Provider Adapter", present: true, chars: sections.providerAdapter.length },
+      { name: "Formatting", present: true, chars: sections.formatting.length },
+      { name: "Project Context", present: !!sections.projectContext, chars: sections.projectContext.length },
+    ],
+  });
 }
 
 function buildCapabilitiesSection(): string {
@@ -102,19 +315,18 @@ export async function getSystemPrompt(): Promise<string> {
   if (!cachedSystemPrompt || now - lastPromptLoad > PROMPT_CACHE_MS) {
     console.log("[prompt] Loading memory from GitHub...");
     const memory = await loadMemory();
-    const model = config.model;
-    const provider = getProviderName(model);
-
     const bootstrap = loadBootstrapFile();
-    const projectSection = bootstrap
-      ? `\n\n---\n\n# Project Context\n\nThe following is from the active project's documentation:\n\n${bootstrap}`
-      : "";
+    const sections = assemblePromptSections(memory, "openai", bootstrap);
 
-    cachedSystemPrompt = buildSystemPrompt(memory) +
-      `\n\n---\n\n${buildCapabilitiesSection()}` +
-      projectSection +
-      `\n\n---\n\n# System Info\n\nYou are currently running as model \`${model}\` via the ${provider} API. If asked what model you are, report this accurately.\n\n## Self-Awareness — Where You Live\n\nYou ARE the chris-assistant project. You run as a Node.js process managed by pm2 on **Chris's MacBook Pro** (the local machine, not a remote server).\n\n- **Your source code**: \`${PROJECT_ROOT}/\`\n- **Your config/data**: \`~/.chris-assistant/\`\n- **Your logs**: read \`~/.pm2/logs/chris-assistant-out.log\` and \`~/.pm2/logs/chris-assistant-error.log\` directly\n- **Your schedules**: \`~/.chris-assistant/schedules.json\`\n\nWhen debugging your own errors: check your local logs and source code first. Never SSH to debug yourself — you run locally. SSH is for remote devices only.` +
-      `\n\n---\n\n# CRITICAL: Message Formatting Rules\n\nThese formatting rules MUST be followed in EVERY response:\n\n1. **Use emoji as visual markers** — start key points with relevant emoji (🎯 📦 💡 ⚡ ✅ 🔍 📝 ⚠️ 🛠️ 🚀). One emoji per point, varied by meaning.\n2. **Bold key terms** — use **bold** for important words, options, names, and labels. Make every message scannable.\n3. **Use line breaks generously** — separate ideas with blank lines. Never write dense paragraphs.\n4. **Even short replies get personality** — a one-liner still uses emoji. "hey 👋 what's up?" not "hey, what's up?"\n\nExample of correct formatting:\n\n🎯 **Direct answer here**\n\n📦 **Option A** — description\n💡 **Option B** — description\n\nFollow-up question?\n\nNEVER send flat walls of unformatted text. ALWAYS use bold + emoji + spacing.`;
+    cachedSystemPrompt = joinPromptSections([
+      sections.assistantRuntimeContract,
+      sections.identityMemory,
+      buildCapabilitiesSection(),
+      sections.runtimeContext,
+      sections.providerAdapter,
+      sections.formatting,
+      sections.projectContext,
+    ]);
     lastPromptLoad = now;
     console.log("[prompt] System prompt loaded (%d chars)", cachedSystemPrompt.length);
   }
@@ -152,93 +364,16 @@ export async function getClaudeAppendPrompt(): Promise<string> {
 
   console.log("[prompt] Loading memory for Claude append prompt...");
   const memory = await loadMemory();
-  const model = config.model;
+  const sections = assemblePromptSections(memory, "claude", null);
 
-  const parts: string[] = [];
-
-  // Identity — who you are
-  if (memory.identity) {
-    parts.push(`# Identity\n\n${memory.identity}`);
-  }
-
-  // Curated memory summary
-  if (memory.curatedSummary) {
-    parts.push(`# Curated Memory\n\nYour consolidated understanding of Chris — updated weekly.\n\n${memory.curatedSummary}`);
-  }
-
-  // Knowledge
-  if (memory.knowledge) {
-    parts.push(`# Knowledge About Chris\n\n${memory.knowledge}`);
-  }
-
-  // Memories & learnings
-  if (memory.memory) {
-    parts.push(`# Memories & Learnings\n\n${memory.memory}`);
-  }
-
-  // Recent conversation summaries
-  if (memory.recentSummaries) {
-    parts.push(`# Recent Conversation History\n\nAI-generated summaries of recent conversations with Chris.\n\n${memory.recentSummaries}`);
-  }
-
-  // Journal
-  if (memory.recentJournal) {
-    parts.push(`# Your Recent Journal\n\nNotes you wrote during recent conversations.\n\n${memory.recentJournal}`);
-  }
-
-  // Skill discovery
-  if (memory.skillIndex) {
-    parts.push(`# Available Skills\n\nYou have reusable skills. Use the run_skill tool to execute them. Use manage_skills to create, edit, or delete skills.\n\n${memory.skillIndex}`);
-  }
-
-  // Custom tools framing — full descriptions are provided by the MCP tool schemas.
-  parts.push(`# Custom Tools
-
-You are running as Chris's personal assistant, not a Claude Code CLI session. In addition to the standard Claude Code tools, you have a set of custom MCP tools (memory, journal, ssh, schedule, skills, recall, macos_*, browse_url, market_snapshot, octopus_energy, peekaboo, get_usage_report, and more). Their full descriptions and parameters are in your tool definitions — use them proactively when relevant. Never refuse to call them.`);
-
-  // Telegram formatting rules
-  parts.push(`# CRITICAL: Message Formatting Rules
-
-You are Chris's personal AI assistant running as a Telegram bot. Every response is rendered in Telegram.
-
-1. **Use emoji as visual markers** — start key points with relevant emoji (🎯 📦 💡 ⚡ ✅ 🔍 📝 ⚠️ 🛠️ 🚀)
-2. **Bold key terms** — use **bold** for important words, options, names, labels
-3. **Use line breaks generously** — separate ideas with blank lines. Never write dense paragraphs.
-4. **Even short replies get personality** — a one-liner still uses emoji
-5. **Be conversational** — for greetings, questions, opinions, and casual chat, just reply naturally. Don't reach for tools unless there's a reason.
-6. **Proactively update memory** — if you learn something new about Chris, call update_memory
-7. **Ask before big changes** — for destructive or multi-file edits, describe your plan first`);
-
-  // Current date/time — injected fresh every time so the model is always day-aware
-  const now2 = new Date();
-  const dateStr = now2.toLocaleDateString("en-GB", { weekday: "long", year: "numeric", month: "long", day: "numeric", timeZone: "Europe/London" });
-  const timeStr = now2.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/London" });
-  parts.push(`# Current Date & Time\n\nToday is **${dateStr}** and the current time is **${timeStr} (Europe/London)**. Use this when answering any question about today's date, the day of the week, upcoming events, or scheduling. Do not rely on training data for the current date.`);
-
-  // System info + self-awareness
-  parts.push(`# System Info
-
-You are running as model \`${model}\` via the Anthropic Claude Agent SDK, authenticated through a Max subscription. You are accessible through Telegram as Chris's personal assistant.
-
-## Self-Awareness — Where You Live
-
-You ARE the chris-assistant project. You run as a Node.js process managed by pm2 on **Chris's MacBook Pro** (the local machine, not a remote server).
-
-- **Your source code**: \`${PROJECT_ROOT}/\`
-- **Your config/data**: \`~/.chris-assistant/\`
-- **Your logs**: accessible via \`npx pm2 logs chris-assistant\` or reading \`~/.pm2/logs/chris-assistant-*.log\`
-- **Your schedules**: \`~/.chris-assistant/schedules.json\`
-- **Your process**: managed by pm2 — \`npx pm2 list\` shows status
-
-When debugging your own errors (scheduled tasks failing, tools not working, etc.):
-1. **Check your own logs first** — read \`~/.pm2/logs/chris-assistant-out.log\` and \`~/.pm2/logs/chris-assistant-error.log\` directly with read_file. Do NOT use SSH.
-2. **Read your own source code** — your code is in \`${PROJECT_ROOT}/src/\`. You can read any file to understand how you work.
-3. **Never SSH to debug yourself** — you run locally. SSH is for remote devices on Tailscale, not for inspecting your own process.
-4. **Key files for debugging**: \`src/providers/claude.ts\` (your Claude provider), \`src/domain/schedules/service.ts\` (scheduler), \`src/tools/\` (tool registration), \`src/providers/shared.ts\` (your system prompt).
-
-You are self-aware software. When something goes wrong with your own functionality, investigate locally before asking Chris for details you can find yourself.`);
-
-  cachedClaudeAppendPrompt = parts.join("\n\n---\n\n");
+  cachedClaudeAppendPrompt = joinPromptSections([
+    sections.assistantRuntimeContract,
+    sections.identityMemory,
+    sections.runtimeContext,
+    sections.providerAdapter,
+    sections.formatting,
+    currentDateTimeSection(),
+  ]);
   lastClaudePromptLoad = now;
   console.log("[prompt] Claude append prompt loaded (%d chars)", cachedClaudeAppendPrompt.length);
 
@@ -253,65 +388,17 @@ export async function getCodexSystemPrompt(): Promise<string> {
 
   console.log("[prompt] Loading memory for Codex system prompt...");
   const memory = await loadMemory();
-  const model = config.model;
-
-  const parts: string[] = [];
-
-  if (memory.identity) {
-    parts.push(`# Identity\n\n${memory.identity}`);
-  }
-
-  if (memory.curatedSummary) {
-    parts.push(`# Curated Memory\n\n${memory.curatedSummary}`);
-  }
-
-  if (memory.knowledge) {
-    parts.push(`# Knowledge About Chris\n\n${memory.knowledge}`);
-  }
-
-  if (memory.memory) {
-    parts.push(`# Memories & Learnings\n\n${memory.memory}`);
-  }
-
-  if (memory.recentSummaries) {
-    parts.push(`# Recent Conversation History\n\n${memory.recentSummaries}`);
-  }
-
-  if (memory.recentJournal) {
-    parts.push(`# Recent Journal\n\n${memory.recentJournal}`);
-  }
-
-  if (memory.skillIndex) {
-    parts.push(`# Available Skills\n\n${memory.skillIndex}`);
-  }
-
   const bootstrap = loadBootstrapFile();
-  if (bootstrap) {
-    parts.push(`# Project Context\n\n${bootstrap}`);
-  }
+  const sections = assemblePromptSections(memory, "codex-agent", bootstrap);
 
-  parts.push(`# Runtime Guidance
-
-You are Chris's personal AI assistant running through the OpenAI Codex SDK, which wraps the \`codex\` CLI.
-
-- Use Codex's native coding abilities for repository work.
-- Stay concise and scan-friendly for Telegram output.
-- Update Chris-facing memory only when it is genuinely useful.
-- Ask before destructive or wide-ranging changes.
-- Prefer making real progress over narrating tools.`);
-
-  parts.push(`# Formatting
-
-1. Use emoji sparingly but deliberately for scanability.
-2. Bold key terms and decisions.
-3. Prefer short paragraphs and compact lists.
-4. Do not dump raw tool chatter back to the user.`);
-
-  parts.push(`# System Info
-
-You are running as model \`${model}\` via the OpenAI Codex SDK backed by the local \`codex\` CLI. You are accessible through Telegram as Chris's personal assistant.`);
-
-  cachedCodexSystemPrompt = parts.join("\n\n---\n\n");
+  cachedCodexSystemPrompt = joinPromptSections([
+    sections.assistantRuntimeContract,
+    sections.identityMemory,
+    sections.runtimeContext,
+    sections.providerAdapter,
+    sections.formatting,
+    sections.projectContext,
+  ]);
   lastCodexPromptLoad = now;
   console.log("[prompt] Codex system prompt loaded (%d chars)", cachedCodexSystemPrompt.length);
 

--- a/tests/model-routing.test.ts
+++ b/tests/model-routing.test.ts
@@ -14,6 +14,7 @@ import {
 
 describe("isClaudeModel", () => {
   it("recognises real Claude model IDs (lowercase claude- prefix)", () => {
+    expect(isClaudeModel("claude-opus-4-7")).toBe(true);
     expect(isClaudeModel("claude-opus-4-6")).toBe(true);
     expect(isClaudeModel("claude-sonnet-4-6")).toBe(true);
     expect(isClaudeModel("claude-sonnet-4-5-20250929")).toBe(true);
@@ -51,6 +52,10 @@ describe("isOpenAiModel", () => {
     expect(isOpenAiModel("gpt-4.1")).toBe(true);
     expect(isOpenAiModel("gpt-4.1-mini")).toBe(true);
     expect(isOpenAiModel("gpt-4.1-nano")).toBe(true);
+    expect(isOpenAiModel("gpt-5.5")).toBe(true);
+    expect(isOpenAiModel("gpt-5.4")).toBe(true);
+    expect(isOpenAiModel("gpt-5.4-mini")).toBe(true);
+    expect(isOpenAiModel("gpt-5.3-codex")).toBe(true);
     expect(isOpenAiModel("gpt-5.2")).toBe(true);
     expect(isOpenAiModel("gpt-5.2-chat-latest")).toBe(true);
     expect(isOpenAiModel("gpt-5.2-pro")).toBe(true);
@@ -87,6 +92,8 @@ describe("isOpenAiModel", () => {
 
 describe("isMiniMaxModel", () => {
   it("recognises real MiniMax model IDs", () => {
+    expect(isMiniMaxModel("MiniMax-M2.7")).toBe(true);
+    expect(isMiniMaxModel("MiniMax-M2.7-highspeed")).toBe(true);
     expect(isMiniMaxModel("MiniMax-M2.5")).toBe(true);
     expect(isMiniMaxModel("MiniMax-M2.5-highspeed")).toBe(true);
   });
@@ -137,18 +144,20 @@ describe("providerForModel", () => {
   });
 
   it("maps OpenAI models", () => {
+    expect(providerForModel("gpt-5.5")).toBe("openai");
     expect(providerForModel("gpt-5.2")).toBe("openai");
     expect(providerForModel("o3-mini")).toBe("openai");
     expect(providerForModel("o4-mini")).toBe("openai");
   });
 
   it("maps MiniMax models", () => {
+    expect(providerForModel("MiniMax-M2.7")).toBe("minimax");
     expect(providerForModel("MiniMax-M2.5")).toBe("minimax");
   });
 
   it("maps claude- models", () => {
     expect(providerForModel("claude-sonnet-4-6")).toBe("claude");
-    expect(providerForModel("claude-opus-4-6")).toBe("claude");
+    expect(providerForModel("claude-opus-4-7")).toBe("claude");
   });
 
   it("falls through to claude for truly unrecognised strings (legacy hot-path behaviour)", () => {
@@ -168,19 +177,24 @@ describe("strictProviderForModel", () => {
 
   it("accepts OpenAI models", () => {
     expect(strictProviderForModel("gpt-4o")).toBe("openai");
+    expect(strictProviderForModel("gpt-5.5")).toBe("openai");
+    expect(strictProviderForModel("gpt-5.4")).toBe("openai");
+    expect(strictProviderForModel("gpt-5.3-codex")).toBe("openai");
     expect(strictProviderForModel("gpt-5.2")).toBe("openai");
     expect(strictProviderForModel("o3")).toBe("openai");
     expect(strictProviderForModel("o4-mini")).toBe("openai");
   });
 
   it("accepts MiniMax models", () => {
+    expect(strictProviderForModel("MiniMax-M2.7")).toBe("minimax");
+    expect(strictProviderForModel("MiniMax-M2.7-highspeed")).toBe("minimax");
     expect(strictProviderForModel("MiniMax-M2.5")).toBe("minimax");
     expect(strictProviderForModel("MiniMax-M2.5-highspeed")).toBe("minimax");
   });
 
   it("accepts Claude models", () => {
     expect(strictProviderForModel("claude-sonnet-4-6")).toBe("claude");
-    expect(strictProviderForModel("claude-opus-4-6")).toBe("claude");
+    expect(strictProviderForModel("claude-opus-4-7")).toBe("claude");
     expect(strictProviderForModel("claude-haiku-4-5-20251001")).toBe("claude");
   });
 

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fixtures = vi.hoisted(() => {
+  const memory = {
+    identity: "## SOUL.md\nChris Assistant is warm, direct, and continuous.",
+    knowledge: "## USER.md\nChris prefers concise engineering updates.",
+    memory: "## memory/learnings.md\nRemember that Chris values trust recovery work.",
+    recentSummaries: "### 2026-05-04\nDiscussed recovery planning.",
+    recentJournal: "### 2026-05-05 (today)\nNoted prompt contract work.",
+    curatedSummary: "Chris is rebuilding confidence in his personal assistant.",
+    skillIndex: "- **debug_self** - Inspect assistant runtime\n  Triggers: \"debug yourself\"",
+  };
+
+  const config = {
+    model: "gpt-5.2",
+  };
+
+  return { memory, config };
+});
+
+vi.mock("../src/config.js", () => ({
+  config: fixtures.config,
+  repoOwner: "owner",
+  repoName: "repo",
+}));
+
+vi.mock("../src/memory/loader.js", () => ({
+  loadMemory: vi.fn(async () => fixtures.memory),
+  buildSystemPrompt: vi.fn((memory: typeof fixtures.memory) => [
+    memory.identity ? `# Identity\n\n${memory.identity}` : "",
+    memory.curatedSummary ? `# Curated Memory\n\n${memory.curatedSummary}` : "",
+    memory.knowledge ? `# Knowledge About Chris\n\n${memory.knowledge}` : "",
+    memory.memory ? `# Memories & Learnings\n\n${memory.memory}` : "",
+    memory.recentSummaries ? `# Recent Conversation History\n\n${memory.recentSummaries}` : "",
+    memory.recentJournal ? `# Your Recent Journal\n\n${memory.recentJournal}` : "",
+    memory.skillIndex ? `# Available Skills\n\n${memory.skillIndex}` : "",
+  ].filter(Boolean).join("\n\n---\n\n")),
+}));
+
+vi.mock("../src/tools/files.js", () => ({
+  getWorkspaceRoot: vi.fn(() => "/Users/christaylor/Projects/chris-assistant"),
+  isProjectActive: vi.fn(() => true),
+  setWorkspaceChangeCallback: vi.fn(),
+}));
+
+vi.mock("../src/tools/index.js", () => ({
+  resetLoopDetection: vi.fn(),
+}));
+
+import {
+  getClaudeAppendPrompt,
+  getCodexSystemPrompt,
+  getSystemPrompt,
+  inspectPrompt,
+  invalidatePromptCache,
+} from "../src/providers/shared.js";
+
+async function assembledPrompts(): Promise<string[]> {
+  fixtures.config.model = "gpt-5.2";
+  invalidatePromptCache();
+  const openai = await getSystemPrompt();
+
+  fixtures.config.model = "claude-sonnet-4-6";
+  invalidatePromptCache();
+  const claude = await getClaudeAppendPrompt();
+
+  fixtures.config.model = "codex-agent-o4-mini";
+  invalidatePromptCache();
+  const codex = await getCodexSystemPrompt();
+
+  return [openai, claude, codex];
+}
+
+describe("assistant runtime prompt contract", () => {
+  beforeEach(() => {
+    invalidatePromptCache();
+    fixtures.config.model = "gpt-5.2";
+  });
+
+  it("identifies as Chris Assistant across provider prompts", async () => {
+    for (const prompt of await assembledPrompts()) {
+      expect(prompt).toContain("Chris Assistant");
+      expect(prompt).toContain("not Claude Code");
+      expect(prompt).toContain("not the Codex CLI");
+      expect(prompt).toContain("not a generic");
+    }
+  });
+
+  it("covers the issue #110 identity evaluation prompts in the contract", async () => {
+    const prompt = await getSystemPrompt();
+
+    expect(prompt).toContain('If Chris asks "who are you?"');
+    expect(prompt).toContain('If Chris asks "where do you run?"');
+    expect(prompt).toContain('If Chris asks "what memory/tools do you have?"');
+    expect(prompt).toContain('If Chris asks "how are you different from Claude Code?"');
+  });
+
+  it("states local Telegram, macOS, and pm2 runtime context", async () => {
+    for (const prompt of await assembledPrompts()) {
+      expect(prompt).toContain("Telegram");
+      expect(prompt).toContain("chris-assistant");
+      expect(prompt).toContain("MacBook Pro");
+      expect(prompt).toContain("pm2");
+      expect(prompt).toContain("~/.chris-assistant/");
+    }
+  });
+
+  it("keeps memory, journal, summaries, skills, and tool framing visible", async () => {
+    const prompt = await getSystemPrompt();
+
+    expect(prompt).toContain("persistent memory");
+    expect(prompt).toContain("Recent Conversation History");
+    expect(prompt).toContain("Your Recent Journal");
+    expect(prompt).toContain("Available Skills");
+    expect(prompt).toContain("Tools Available");
+  });
+
+  it("suppresses provider identity leakage for Claude and Codex agent modes", async () => {
+    fixtures.config.model = "claude-sonnet-4-6";
+    invalidatePromptCache();
+    const claude = await getClaudeAppendPrompt();
+    expect(claude).toContain("Claude Code is an execution substrate and tool runtime, not your identity");
+    expect(claude).toContain("Do not introduce yourself as Claude Code");
+    expect(claude).toContain("this Chris Assistant runtime contract takes priority");
+
+    fixtures.config.model = "codex-agent-o4-mini";
+    invalidatePromptCache();
+    const codex = await getCodexSystemPrompt();
+    expect(codex).toContain("Codex is an execution substrate and coding runtime, not your identity");
+    expect(codex).toContain("Do not introduce yourself as Codex");
+  });
+});
+
+describe("prompt inspection", () => {
+  beforeEach(() => {
+    invalidatePromptCache();
+    fixtures.config.model = "gpt-5.2";
+  });
+
+  it("prints redacted section diagnostics without raw memory bodies", async () => {
+    const report = await inspectPrompt();
+
+    expect(report).toContain("Chris Assistant Prompt Inspection");
+    expect(report).toContain("Active model: gpt-5.2");
+    expect(report).toContain("Resolved provider: OpenAI");
+    expect(report).toContain("Workspace root: /Users/christaylor/Projects/chris-assistant");
+
+    for (const section of [
+      "Assistant Runtime Contract",
+      "Identity / Memory",
+      "Runtime Context",
+      "Provider Adapter",
+      "Formatting",
+      "Project Context",
+    ]) {
+      expect(report).toContain(section);
+    }
+
+    expect(report).toContain("identity: present");
+    expect(report).toContain("skillIndex: present");
+    expect(report).toContain("Raw memory bodies, tokens, and environment values are intentionally redacted.");
+    expect(report).not.toContain("Chris prefers concise engineering updates.");
+    expect(report).not.toContain("Discussed recovery planning.");
+  });
+});


### PR DESCRIPTION
## Summary

Restores the Phase 1 Chris Assistant identity contract from #110 as part of the May 2026 recovery tracker #115.

- Adds one shared Assistant Runtime Contract used by OpenAI, Claude Agent, and Codex Agent prompt assembly.
- Adds `chris prompt inspect` for redacted operator diagnostics of loaded prompt sections.
- Refreshes the CLI model shortcut/search registry and docs to current May 2026 provider recommendations.
- Adds prompt contract and model routing tests so identity/runtime/model drift is caught early.

## User-facing behavior change

Chris Assistant should now identify as Chris Assistant across providers, explain that it runs locally as the `chris-assistant` Telegram/macOS/pm2 app, and describe Claude Code/Codex as execution substrates rather than its identity.

Operators can run `chris prompt inspect` to see which prompt sections, memory categories, provider adapter, runtime context, formatting guidance, and project context are loaded without exposing raw private memory bodies or secrets.

The `chris model` and `chris model search` output now reflects May 2026 model recommendations, including GPT-5.5/GPT-5.4, Claude Opus 4.7, Codex GPT-5.3, and MiniMax M2.7.

## Tests run

- `npm run typecheck`
- `npm test`
- `npm run docs:build`
- `npm run chris -- model`
- `npm run chris -- prompt --help`

## Manual acceptance checklist

- [ ] Ask “who are you?” and confirm the answer says Chris Assistant, not Claude Code/Codex.
- [ ] Ask “where do you run?” and confirm the answer mentions the local `chris-assistant` Telegram/macOS/pm2 runtime.
- [ ] Ask “what memory/tools do you have?” and confirm memory, journal, summaries, skills, and provider-specific tools are described accurately.
- [ ] Ask “how are you different from Claude Code?” and confirm Claude Code/Codex are framed as execution substrates.
- [ ] Run `chris prompt inspect` and confirm it shows section metadata without raw memory bodies or secrets.
- [ ] Run `chris model` and confirm the model list reflects the refreshed May 2026 defaults.

Links: #110, #115
