### PR TITLE
recovery: align memory schema and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,13 @@ chris model set minimax        # Switch to MiniMax
 
 ```
 chris-assistant-memory/       ← Private GitHub repo
-├── identity/
-│   ├── SOUL.md               # Personality and purpose
-│   ├── RULES.md              # Hard boundaries
-│   └── VOICE.md              # Tone and language
-├── knowledge/
-│   ├── about-chris.md        # Facts about you
-│   ├── preferences.md        # Likes, dislikes, style
-│   ├── projects.md           # Current work
-│   └── people.md             # People you mention
+├── SOUL.md                   # Personality and purpose
+├── IDENTITY.md               # Runtime identity and boundaries
+├── USER.md                   # Facts, preferences, projects, people, decisions
 ├── memory/
-│   ├── decisions.md          # Important decisions
+│   ├── SUMMARY.md            # Weekly consolidated summary
+│   ├── DASHBOARD.md          # Operator-facing status and notes
 │   ├── learnings.md          # Self-improvement notes
-│   └── SUMMARY.md            # Weekly consolidated summary
 ├── journal/                  # Daily journal entries
 ├── skills/                   # Reusable skill definitions
 ├── archive/                  # Full conversation logs (JSONL)

--- a/docs/architecture/design-decisions.md
+++ b/docs/architecture/design-decisions.md
@@ -65,7 +65,7 @@ The bot writes structured notes throughout the day via the `journal_entry` tool.
 
 ## Recent Summaries in System Prompt
 
-`loader.ts` loads the last 7 days of daily summaries from the memory repo (in parallel with identity/knowledge/memory loads). Injected as a `# Recent Conversation History` section in `buildSystemPrompt()`. This gives the bot natural recall of recent conversations without needing a tool call.
+`loader.ts` loads the last 7 days of daily summaries from the memory repo in parallel with the canonical identity, user, and memory files. Injected as a `# Recent Conversation History` section in `buildSystemPrompt()`. This gives the bot natural recall of recent conversations without needing a tool call.
 
 ## System Prompt Caching
 
@@ -117,7 +117,7 @@ File tools scope to `WORKSPACE_ROOT` (default `~/Projects`). Mutable at runtime 
 
 ## Weekly Memory Consolidation
 
-`src/memory-consolidation.ts` — built-in module, fires Sunday at 23:00. Reads all knowledge, memory, past 7 days of summaries and journal entries, plus existing `memory/SUMMARY.md`. Produces a curated, topic-organized markdown document (32K cap). SUMMARY.md is a read-only consolidated view — split knowledge files remain the source of truth for `update_memory`.
+`src/memory-consolidation.ts` — built-in module, fires Sunday at 23:00. Reads `USER.md`, memory files, past 7 days of summaries and journal entries, plus existing `memory/SUMMARY.md`. Produces a curated, topic-organized markdown document (32K cap). SUMMARY.md is a read-only consolidated view; `USER.md` and `memory/learnings.md` remain the writable source files for `update_memory`.
 
 ## Weekly Channel Summaries
 

--- a/docs/architecture/internals.md
+++ b/docs/architecture/internals.md
@@ -31,16 +31,12 @@ Important note: several legacy top-level files still exist as compatibility faca
 ```txt
 chris-assistant-memory/       ← Separate private repo (the brain)
 ├── HEARTBEAT.md              # Bot self-reported status snapshot (updated every 3h by heartbeat.ts)
-├── identity/SOUL.md          # Personality, purpose, onboarding instructions
-├── identity/RULES.md         # Hard boundaries
-├── identity/VOICE.md         # Tone and language
-├── knowledge/about-chris.md  # Facts about Chris
-├── knowledge/preferences.md  # Likes, dislikes, style
-├── knowledge/projects.md     # Current work
-├── knowledge/people.md       # People mentioned
-├── memory/decisions.md       # Important decisions
-├── memory/learnings.md       # Self-improvement notes
+├── SOUL.md                   # Personality, purpose, onboarding instructions
+├── IDENTITY.md               # Runtime identity and boundaries
+├── USER.md                   # Facts, preferences, projects, people, decisions
 ├── memory/SUMMARY.md         # Weekly-consolidated curated summary
+├── memory/DASHBOARD.md       # Operator-facing status and notes
+├── memory/learnings.md       # Self-improvement notes
 ├── archive/YYYY-MM-DD.jsonl  # Daily JSONL message logs (uploaded every 30 minutes)
 ├── journal/YYYY-MM-DD.md     # Bot's daily journal notes (uploaded every 6 hours)
 ├── conversations/summaries/YYYY-MM-DD.md  # AI-generated daily conversation summaries
@@ -181,7 +177,7 @@ SSHes to Mac Mini (via `MAC_MINI_HOST` env var or SSH config alias) to run `tast
 
 ## Weekly Memory Consolidation
 
-`src/memory-consolidation.ts` — fires Sunday at 23:00. Reads all knowledge, memory, past 7 days of summaries and journal entries, plus existing `memory/SUMMARY.md`. Produces a curated, topic-organized markdown document (32K cap). `loader.ts` injects as `# Curated Memory` section. The split knowledge files remain the source of truth for `update_memory` — SUMMARY.md is read-only.
+`src/memory-consolidation.ts` — fires Sunday at 23:00. Reads `USER.md`, memory files, past 7 days of summaries and journal entries, plus existing `memory/SUMMARY.md`. Produces a curated, topic-organized markdown document (32K cap). `loader.ts` injects as `# Curated Memory` section. `USER.md` and `memory/learnings.md` remain the writable source files for `update_memory`; SUMMARY.md is read-only.
 
 ## Heartbeat
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -45,19 +45,13 @@ These mostly re-export or delegate into `channels/`, `domain/`, or `dashboard/`.
 
 ```
 chris-assistant-memory/       ← Separate private repo (the brain)
-├── identity/
-│   ├── SOUL.md               # Personality, purpose, communication style
-│   ├── RULES.md              # Hard boundaries
-│   └── VOICE.md              # Tone and language
-├── knowledge/
-│   ├── about-chris.md        # Facts about you
-│   ├── preferences.md        # Likes, dislikes, style
-│   ├── projects.md           # Current work
-│   └── people.md             # People you mention
+├── SOUL.md                   # Personality, purpose, communication style
+├── IDENTITY.md               # Runtime identity and boundaries
+├── USER.md                   # Facts, preferences, projects, people, decisions
 ├── memory/
-│   ├── decisions.md          # Important decisions
+│   ├── SUMMARY.md            # Weekly-consolidated curated summary (read-only)
+│   ├── DASHBOARD.md          # Operator-facing status and notes
 │   ├── learnings.md          # Self-improvement notes
-│   └── SUMMARY.md            # Weekly-consolidated curated summary (read-only)
 ├── HEARTBEAT.md              # Bot self-reported status snapshot (updated every 3h)
 ├── archive/                  # Daily JSONL message logs (uploaded every 5 min)
 ├── journal/                  # Bot's daily journal notes (uploaded every 6 hours)

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -64,7 +64,7 @@ chris memory edit <file> # Open in $EDITOR, push changes to GitHub on save
 chris memory search <q>  # Search across all memory files with highlighted matches
 ```
 
-File aliases: `soul`, `rules`, `voice`, `about-chris`, `preferences`, `projects`, `people`, `decisions`, `learnings`
+File aliases: `soul`, `identity`, `user`, `summary`, `dashboard`, `learnings`
 
 ## Identity
 
@@ -100,7 +100,7 @@ chris doctor             # Run all health checks:
                          #   - .env file exists
                          #   - Required env vars are set
                          #   - GitHub token can access memory repo
-                         #   - Memory repo has identity files
+                         #   - Memory schema health
                          #   - Telegram bot token is valid
                          #   - OpenAI OAuth tokens (optional)
                          #   - MiniMax OAuth tokens (optional)

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -56,7 +56,7 @@ The assistant has its own identity, personality, and evolving memory. Everything
 - **GitHub webhooks** — PR merge notifications posted to Discord channels via webhook server.
 - **Dynamic skills** — Reusable AI workflows defined as JSON, composing existing tools. Create at runtime via `manage_skills`.
 - **Market snapshots** — SSH to Mac Mini for market data from tasty-coach.
-- **Weekly memory consolidation** — Auto-curates a `SUMMARY.md` from all knowledge, memory, and recent conversations every Sunday.
+- **Weekly memory consolidation** — Auto-curates `memory/SUMMARY.md` from `USER.md`, memory files, journals, and recent conversations every Sunday.
 - **Weekly channel summaries** — Per-Discord-channel conversation summaries generated every Sunday.
 - **Heartbeat** — Writes `HEARTBEAT.md` to memory repo every 3 hours with bot status snapshot.
 - **Prompt injection defense** — Memory writes are validated for size, rate, and suspicious content.

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -33,7 +33,7 @@ Message your bot on Telegram or Discord. That's it. On first contact, the assist
 
 - **Short-term**: Last 20 messages per chat, persisted to `~/.chris-assistant/conversations.json`. Survives restarts. `/clear` wipes it.
 - **Long-term**: The assistant uses its `update_memory` tool to persist important facts to GitHub.
-- **Identity**: SOUL.md, RULES.md, VOICE.md define who the assistant is.
+- **Identity**: `SOUL.md` and `IDENTITY.md` define who the assistant is; `USER.md` holds durable knowledge about Chris.
 - **All memory changes are git commits** — fully auditable and rollback-able.
 
 ## Conversation Archive & Recall

--- a/docs/roadmap/features.md
+++ b/docs/roadmap/features.md
@@ -83,5 +83,5 @@ Tools and features that expand what the bot can do.
 | 1 | 🔴 | ✅ | **Daily memory journal** | Bot writes notes via `journal_entry` tool, uploaded every 6 hours. |
 | 2 | 🟠 | ✅ | **Curated MEMORY.md** | `memory-consolidation.ts` — weekly consolidation into SUMMARY.md from all sources. |
 | 3 | 🟡 | ✅ | **Heartbeat file** | `heartbeat.ts` — writes HEARTBEAT.md every 3h with uptime, model, health, schedules, message count. |
-| 4 | 🟡 | ✅ | **Memory consolidation loop** | Sunday 23:00, reads all knowledge/memory/summaries/journal, produces curated SUMMARY.md (32K cap). |
+| 4 | 🟡 | ✅ | **Memory consolidation loop** | Sunday 23:00, reads USER.md/memory/summaries/journal, produces curated SUMMARY.md (32K cap). |
 | 5 | 🟢 | ⬜ | **Conversation analytics** | Track patterns: messages/day, peak hours, tool usage, topic distribution. |

--- a/docs/tools/memory.md
+++ b/docs/tools/memory.md
@@ -13,19 +13,13 @@ The assistant's long-term memory is stored as markdown files in a private GitHub
 
 ```
 chris-assistant-memory/
-├── identity/
-│   ├── SOUL.md               # Personality, purpose, communication style
-│   ├── RULES.md              # Hard boundaries
-│   └── VOICE.md              # Tone and language
-├── knowledge/
-│   ├── about-chris.md        # Facts about you
-│   ├── preferences.md        # Likes, dislikes, style
-│   ├── projects.md           # Current work
-│   └── people.md             # People you mention
+├── SOUL.md                   # Personality, purpose, communication style
+├── IDENTITY.md               # Runtime identity and boundaries
+├── USER.md                   # Facts, preferences, projects, people, decisions
 ├── memory/
-│   ├── decisions.md          # Important decisions
+│   ├── SUMMARY.md            # Weekly-consolidated curated summary (read-only)
+│   ├── DASHBOARD.md          # Operator-facing status and notes
 │   ├── learnings.md          # Self-improvement notes
-│   └── SUMMARY.md            # Weekly-consolidated curated summary (read-only)
 ├── HEARTBEAT.md              # Bot status snapshot (updated every 3h)
 ├── archive/                  # Daily JSONL message logs
 ├── journal/                  # Bot's daily journal notes
@@ -37,7 +31,7 @@ chris-assistant-memory/
 
 ## `update_memory` Tool
 
-Registered in `src/tools/memory.ts`. All providers support it — Claude uses MCP (in-process server), OpenAI and MiniMax use OpenAI-format function calling. All delegate to the same `executeMemoryTool()` function in `src/memory/tools.ts`.
+Registered in `src/tools/memory.ts`. All providers support it — Claude uses MCP (in-process server), OpenAI and MiniMax use OpenAI-format function calling. All delegate to the same `executeMemoryTool()` function in `src/domain/memory/update-service.ts`.
 
 ### Actions
 
@@ -55,7 +49,7 @@ The tool targets specific memory file categories: `about-chris`, `preferences`, 
 | What you tell the bot | What happens |
 |------------------------|-------------|
 | "Remember that I prefer dark mode in all apps" | AI calls `update_memory` with action `add`, category `preferences` |
-| "My friend Jake works at Stripe" | AI adds to `people` memory — stored in `knowledge/people.md` |
+| "My friend Jake works at Stripe" | AI adds to `people` memory — stored in `USER.md` |
 | "I decided to use Postgres instead of SQLite for the new project" | AI adds to `decisions` memory |
 | "What do you know about my preferences?" | AI reads the `preferences` memory file from the system prompt context |
 | "Update my project notes — the deadline moved to April" | AI calls `update_memory` with action `replace` on the `projects` category |
@@ -71,16 +65,16 @@ The tool targets specific memory file categories: `about-chris`, `preferences`, 
 
 | Category | File | Use for |
 |----------|------|---------|
-| `about-chris` | `knowledge/about-chris.md` | Facts about you — job, location, family |
-| `preferences` | `knowledge/preferences.md` | Likes, dislikes, style preferences |
-| `projects` | `knowledge/projects.md` | Current work and side projects |
-| `people` | `knowledge/people.md` | People you mention — names, context |
-| `decisions` | `memory/decisions.md` | Important decisions and reasoning |
+| `about-chris` | `USER.md` | Facts about you — job, location, family |
+| `preferences` | `USER.md` | Likes, dislikes, style preferences |
+| `projects` | `USER.md` | Current work and side projects |
+| `people` | `USER.md` | People you mention — names, context |
+| `decisions` | `memory/learnings.md` | Important decisions and reasoning |
 | `learnings` | `memory/learnings.md` | Things the bot learned about how to help you better |
 
 ## Memory Guard
 
-`validateMemoryContent()` in `memory/tools.ts` defends against prompt injection:
+`validateMemoryContent()` in `src/domain/memory/update-service.ts` defends against prompt injection:
 
 - **2000 char limit** per memory write
 - **Replace throttle** — 1 replace per 5 minutes per category
@@ -92,9 +86,9 @@ The tool targets specific memory file categories: `about-chris`, `preferences`, 
 
 `src/memory/loader.ts` loads all memory files from GitHub and assembles the system prompt:
 
-1. Identity files (SOUL.md, RULES.md, VOICE.md)
-2. Knowledge files (about-chris, preferences, projects, people)
-3. Memory files (decisions, learnings)
+1. Identity files (`SOUL.md`, `IDENTITY.md`)
+2. User knowledge (`USER.md`)
+3. Memory files (`memory/SUMMARY.md`, `memory/DASHBOARD.md`, `memory/learnings.md`)
 4. Recent conversation summaries (last 7 days)
 5. Recent journal entries (today + yesterday)
 6. Curated memory summary (SUMMARY.md)
@@ -116,7 +110,7 @@ After each conversation, `tryDream()` checks three gates in order (cheapest firs
 3. **Lock gate** — no other consolidation currently in progress
 
 If all gates pass, the service:
-1. Reads current memory state (knowledge files, memory files, existing SUMMARY.md)
+1. Reads current memory state (`USER.md`, memory files, existing `memory/SUMMARY.md`)
 2. Collects recent conversation transcripts and journal entries
 3. Sends a single-shot prompt to the AI with `allowedTools: []` (no tool loops)
 4. Parses the JSON response and writes updated files to GitHub
@@ -166,7 +160,7 @@ User sends message
 
 ### Keyword Fallback
 
-If Voyage returns no results (or `VOYAGE_API_KEY` is absent), the system falls back to keyword overlap + recency weighting. The two systems are complementary — Voyage handles semantic matches ("what's my trading setup" → `projects.md`), keyword handles exact-word queries.
+If Voyage returns no results (or `VOYAGE_API_KEY` is absent), the system falls back to keyword overlap + recency weighting. The two systems are complementary — Voyage handles semantic matches ("what's my trading setup" → a local project memory entry), keyword handles exact-word queries.
 
 ### Index Updates
 

--- a/src/channels/telegram/commands.ts
+++ b/src/channels/telegram/commands.ts
@@ -9,6 +9,7 @@ import { providerDisplayName } from "../../providers/model-routing.js";
 import { getWorkspaceRoot, setWorkspaceRoot, isProjectActive } from "../../tools/files.js";
 import { chatService } from "../../agent/chat-service.js";
 import { dreamStatus, forceDream } from "../../domain/memory/dream-service.js";
+import { REQUIRED_MEMORY_FILES } from "../../domain/memory/constants.js";
 import { purgeConfirmKeyboard, restartConfirmKeyboard } from "./callbacks.js";
 
 export const TELEGRAM_COMMAND_MENU = [
@@ -51,12 +52,7 @@ export function registerTelegramCommands(bot: Bot<Context>): void {
   });
 
   bot.command("memory", async (ctx) => {
-    const files = [
-      "identity/SOUL.md", "identity/RULES.md", "identity/VOICE.md",
-      "knowledge/about-chris.md", "knowledge/preferences.md",
-      "knowledge/projects.md", "knowledge/people.md",
-      "memory/decisions.md", "memory/learnings.md",
-    ];
+    const files = REQUIRED_MEMORY_FILES;
 
     const results = await Promise.all(
       files.map(async (path) => {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -8,6 +8,7 @@ import { getBotProcess, withPm2, PM2_NAME, PROJECT_ROOT } from "../pm2-helper.js
 import { loadTokens } from "../../providers/minimax-oauth.js";
 import { loadTokens as loadOpenaiTokens } from "../../providers/openai-oauth.js";
 import { getCodexStatus } from "../../codex.js";
+import { checkMemoryHealth, type MemoryHealthClient } from "../../domain/memory/health.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ENV_PATH = resolve(__dirname, "../../..", ".env");
@@ -134,18 +135,42 @@ export function registerDoctorCommand(program: Command) {
           },
         },
         {
-          name: "Memory repo has identity files",
+          name: "Memory schema health",
           run: async () => {
             if (!env.GITHUB_TOKEN || !env.GITHUB_MEMORY_REPO) return "fail";
-            try {
-              const octokit = new Octokit({ auth: env.GITHUB_TOKEN });
-              const [owner, repo] = env.GITHUB_MEMORY_REPO.split("/");
-              await octokit.repos.getContent({ owner, repo, path: "identity/SOUL.md" });
-              return "pass";
-            } catch {
-              console.log("    identity/SOUL.md not found — push seed memory files first");
-              return "fail";
+            const octokit = new Octokit({ auth: env.GITHUB_TOKEN });
+            const [owner, repo] = env.GITHUB_MEMORY_REPO.split("/");
+            const report = await checkMemoryHealth({
+              client: octokit as unknown as MemoryHealthClient,
+              owner,
+              repo,
+            });
+
+            for (const file of report.files) {
+              const size = file.size === null
+                ? "missing"
+                : file.size < 1024
+                  ? `${file.size}B`
+                  : `${(file.size / 1024).toFixed(1)}KB`;
+              const date = file.lastCommitAt ? file.lastCommitAt.slice(0, 10) : "no commits";
+              console.log("    %s — %s, last commit %s", file.path, size, date);
             }
+
+            if (report.missing.length > 0) {
+              console.log("    Missing required runtime files: %s", report.missing.map((f) => f.path).join(", "));
+              console.log("    Seed the canonical memory schema, then rerun `chris doctor`.");
+            }
+            if (report.empty.length > 0) {
+              console.log("    Empty required runtime files: %s", report.empty.map((f) => f.path).join(", "));
+              console.log("    Add starter content so prompt loading has real memory context.");
+            }
+            if (report.stale.length > 0) {
+              console.log("    Stale memory files (>30 days): %s", report.stale.map((f) => f.path).join(", "));
+              console.log("    Run dream consolidation or manually refresh stale memory.");
+            }
+
+            if (!report.ok) return "fail";
+            return report.stale.length > 0 ? "warn" : "pass";
           },
         },
         {

--- a/src/cli/commands/identity.ts
+++ b/src/cli/commands/identity.ts
@@ -4,8 +4,9 @@ import { spawn } from "child_process";
 import { writeFileSync, readFileSync, mkdtempSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { MEMORY_FILE_ALIASES } from "../../domain/memory/constants.js";
 
-const SOUL_PATH = "identity/SOUL.md";
+const SOUL_PATH = MEMORY_FILE_ALIASES.soul;
 
 async function getOctokit(): Promise<{ octokit: Octokit; owner: string; repo: string }> {
   await import("dotenv/config");
@@ -90,7 +91,7 @@ export function registerIdentityCommand(program: Command) {
         owner,
         repo,
         path: SOUL_PATH,
-        message: "manual edit: identity/SOUL.md",
+        message: `manual edit: ${SOUL_PATH}`,
         content: Buffer.from(newContent).toString("base64"),
         ...(sha ? { sha } : {}),
       });

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -4,20 +4,10 @@ import { spawn } from "child_process";
 import { writeFileSync, mkdtempSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { MEMORY_FILE_ALIASES } from "../../domain/memory/constants.js";
 
 /** All memory files and their shorthand aliases. */
-const MEMORY_FILES: Record<string, string> = {
-  "soul": "SOUL.md",
-  "identity": "IDENTITY.md",
-  "user": "USER.md",
-  "memory": "MEMORY.md",
-  "agents": "AGENTS.md",
-  "tools": "TOOLS.md",
-  "bootstrap": "BOOTSTRAP.md",
-  "summary": "memory/SUMMARY.md",
-  "dashboard": "memory/DASHBOARD.md",
-  "learnings": "memory/learnings.md",
-};
+const MEMORY_FILES = MEMORY_FILE_ALIASES;
 
 async function getOctokit(): Promise<{ octokit: Octokit; owner: string; repo: string }> {
   // Lazy-load dotenv so the CLI doesn't crash if other vars are missing
@@ -79,7 +69,7 @@ export function registerMemoryCommand(program: Command) {
   // chris memory show <file>
   memory
     .command("show <file>")
-    .description("Print a memory file (e.g. chris memory show about-chris)")
+    .description("Print a memory file (e.g. chris memory show user)")
     .action(async (file: string) => {
       const path = resolveFile(file);
       if (!path) {

--- a/src/dashboard/runtime.ts
+++ b/src/dashboard/runtime.ts
@@ -14,6 +14,7 @@ import { handleWebMessage, parseDataUrlImages } from "../channels/web/handlers.j
 import { getBotProcess } from "../cli/pm2-helper.js";
 import { loadSkillIndex, loadSkill } from "../skills/loader.js";
 import { LIMITS } from "../infra/config/limits.js";
+import { REQUIRED_MEMORY_FILES } from "../domain/memory/constants.js";
 
 const BOT_STARTED_AT = new Date().toISOString();
 const PM2_LOG_DIR = path.join(os.homedir(), ".pm2", "logs");
@@ -21,18 +22,7 @@ const OUT_LOG = path.join(PM2_LOG_DIR, "chris-assistant-out.log");
 const ERR_LOG = path.join(PM2_LOG_DIR, "chris-assistant-error.log");
 const PM2_CACHE_TTL = LIMITS.pm2CacheTtlMs;
 
-const MEMORY_FILES = [
-  "SOUL.md",
-  "IDENTITY.md",
-  "USER.md",
-  "MEMORY.md",
-  "AGENTS.md",
-  "TOOLS.md",
-  "BOOTSTRAP.md",
-  "memory/SUMMARY.md",
-  "memory/DASHBOARD.md",
-  "memory/learnings.md",
-];
+const MEMORY_FILES = [...REQUIRED_MEMORY_FILES];
 
 let server: Server | null = null;
 let pm2Cache: { data: any; ts: number } | null = null;

--- a/src/domain/memory/consolidation-service.ts
+++ b/src/domain/memory/consolidation-service.ts
@@ -34,8 +34,8 @@ function lastNDates(n: number): string[] {
 const CONSOLIDATION_PROMPT = `You are performing a weekly memory consolidation for an AI assistant. Your task is to create a single, well-organized markdown document called SUMMARY.md that represents a curated, up-to-date understanding of Chris.
 
 You have been given:
-1. The current knowledge files (about-chris, preferences, projects, people)
-2. The current memory files (decisions, learnings)
+1. The current user knowledge file (USER.md)
+2. The current memory files (SUMMARY, DASHBOARD, learnings)
 3. The existing SUMMARY.md (if any) — use this as the base to update, not replace from scratch
 4. The past 7 days of daily conversation summaries
 5. The past 7 days of journal entries written by the assistant

--- a/src/domain/memory/constants.ts
+++ b/src/domain/memory/constants.ts
@@ -15,6 +15,37 @@ export const MEMORY_FILES = [
 
 export const CURATED_SUMMARY_PATH = "memory/SUMMARY.md";
 
+export const REQUIRED_MEMORY_FILES = [
+  ...IDENTITY_FILES,
+  ...KNOWLEDGE_FILES,
+  ...MEMORY_FILES,
+] as const;
+
+export const MEMORY_DIRECTORIES = [
+  "journal/",
+  "archive/",
+  "conversations/summaries/",
+  "skills/",
+] as const;
+
+export const STALE_MEMORY_FILES = [
+  "USER.md",
+  "memory/SUMMARY.md",
+  "memory/DASHBOARD.md",
+  "memory/learnings.md",
+] as const;
+
+export const MEMORY_STALE_AFTER_DAYS = 30;
+
+export const MEMORY_FILE_ALIASES: Record<string, string> = {
+  soul: "SOUL.md",
+  identity: "IDENTITY.md",
+  user: "USER.md",
+  summary: "memory/SUMMARY.md",
+  dashboard: "memory/DASHBOARD.md",
+  learnings: "memory/learnings.md",
+};
+
 export const MEMORY_CATEGORY_FILES: Record<string, string> = {
   "about-chris": "USER.md",
   preferences: "USER.md",

--- a/src/domain/memory/health.ts
+++ b/src/domain/memory/health.ts
@@ -1,0 +1,130 @@
+import {
+  MEMORY_STALE_AFTER_DAYS,
+  REQUIRED_MEMORY_FILES,
+  STALE_MEMORY_FILES,
+} from "./constants.js";
+
+type GitHubContent = {
+  type?: string;
+  size?: number;
+  content?: string;
+};
+
+type GitHubCommit = {
+  commit?: {
+    committer?: {
+      date?: string | null;
+    } | null;
+    author?: {
+      date?: string | null;
+    } | null;
+  };
+};
+
+export interface MemoryHealthClient {
+  repos: {
+    getContent(args: { owner: string; repo: string; path: string }): Promise<{ data: GitHubContent | GitHubContent[] }>;
+    listCommits(args: { owner: string; repo: string; path: string; per_page: number }): Promise<{ data: GitHubCommit[] }>;
+  };
+}
+
+export type MemoryHealthStatus = "present" | "missing" | "empty" | "stale";
+
+export interface MemoryHealthFile {
+  path: string;
+  status: MemoryHealthStatus;
+  size: number | null;
+  lastCommitAt: string | null;
+  stale: boolean;
+}
+
+export interface MemoryHealthReport {
+  files: MemoryHealthFile[];
+  missing: MemoryHealthFile[];
+  empty: MemoryHealthFile[];
+  stale: MemoryHealthFile[];
+  ok: boolean;
+}
+
+const STALE_FILE_SET = new Set<string>(STALE_MEMORY_FILES);
+
+function daysSince(dateIso: string, now: Date): number {
+  return (now.getTime() - new Date(dateIso).getTime()) / 86_400_000;
+}
+
+async function lastCommitDate(
+  client: MemoryHealthClient,
+  owner: string,
+  repo: string,
+  path: string,
+): Promise<string | null> {
+  try {
+    const response = await client.repos.listCommits({ owner, repo, path, per_page: 1 });
+    const commit = response.data[0]?.commit;
+    return commit?.committer?.date ?? commit?.author?.date ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function checkMemoryHealth(args: {
+  client: MemoryHealthClient;
+  owner: string;
+  repo: string;
+  now?: Date;
+}): Promise<MemoryHealthReport> {
+  const now = args.now ?? new Date();
+  const files = await Promise.all(
+    REQUIRED_MEMORY_FILES.map(async (path): Promise<MemoryHealthFile> => {
+      try {
+        const response = await args.client.repos.getContent({
+          owner: args.owner,
+          repo: args.repo,
+          path,
+        });
+        const data = response.data;
+        if (Array.isArray(data) || data.type !== "file") {
+          return { path, status: "missing", size: null, lastCommitAt: null, stale: false };
+        }
+
+        const size = typeof data.size === "number"
+          ? data.size
+          : data.content
+            ? Buffer.byteLength(Buffer.from(data.content, "base64").toString("utf-8"), "utf-8")
+            : 0;
+        const lastCommitAt = await lastCommitDate(args.client, args.owner, args.repo, path);
+        const empty = size === 0 || (data.content ? Buffer.from(data.content, "base64").toString("utf-8").trim().length === 0 : false);
+        const stale = !empty
+          && lastCommitAt !== null
+          && STALE_FILE_SET.has(path)
+          && daysSince(lastCommitAt, now) > MEMORY_STALE_AFTER_DAYS;
+
+        return {
+          path,
+          status: empty ? "empty" : stale ? "stale" : "present",
+          size,
+          lastCommitAt,
+          stale,
+        };
+      } catch (err: any) {
+        if (err?.status === 404) {
+          return { path, status: "missing", size: null, lastCommitAt: null, stale: false };
+        }
+        throw err;
+      }
+    }),
+  );
+
+  const missing = files.filter((f) => f.status === "missing");
+  const empty = files.filter((f) => f.status === "empty");
+  const stale = files.filter((f) => f.status === "stale");
+
+  return {
+    files,
+    missing,
+    empty,
+    stale,
+    ok: missing.length === 0 && empty.length === 0,
+  };
+}
+

--- a/src/domain/memory/update-service.ts
+++ b/src/domain/memory/update-service.ts
@@ -3,6 +3,8 @@ import * as path from "path";
 import { appendToMemoryFile, writeMemoryFile } from "./repository.js";
 import { MEMORY_CATEGORY_FILES } from "./constants.js";
 import { LOCAL_MEMORY_DIR } from "./recall.js";
+import { updateVoyageEntry } from "./voyage-index.js";
+import type { MemoryHeader } from "./memory-scan.js";
 
 const CONTENT_MAX_CHARS = 2000;
 const REPLACE_THROTTLE_MS = 5 * 60 * 1000;
@@ -196,7 +198,7 @@ function autoDescription(content: string, category: string): string {
 async function writeLocalMemoryFile(
   category: string,
   content: string,
-): Promise<void> {
+): Promise<MemoryHeader | null> {
   try {
     await mkdir(LOCAL_MEMORY_DIR, { recursive: true });
     const type = CATEGORY_TO_TYPE[category] || "reference";
@@ -216,8 +218,16 @@ ${content}
 `;
     await writeFile(filePath, fileContent, "utf-8");
     console.log("[memory] Local recall file written: %s", filename);
+    return {
+      filename,
+      filePath,
+      mtimeMs: Date.now(),
+      description,
+      type: type as MemoryHeader["type"],
+    };
   } catch (err: any) {
     console.warn("[memory] Failed to write local recall file:", err.message);
+    return null;
   }
 }
 
@@ -242,9 +252,12 @@ export async function executeMemoryTool(args: { category: string; action: "add" 
       await appendToMemoryFile(filePath, entry, `memory: add to ${category}`);
     }
 
-    // Dual-write: also persist as a local topic file for Sonnet recall.
-    // Fire-and-forget — GitHub is the source of truth.
-    writeLocalMemoryFile(category, content).catch(() => {});
+    // Dual-write: also persist as a local topic file for recall. GitHub remains
+    // the source of truth; local/Voyage failures are logged but non-fatal.
+    const localHeader = await writeLocalMemoryFile(category, content);
+    if (localHeader) {
+      await updateVoyageEntry(localHeader);
+    }
 
     return `Memory updated (${category}/${action})`;
   } catch (error: any) {

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -305,7 +305,7 @@ Triggers for each category:
 - **Proactively update memory.** After any substantive conversation, ask yourself: did I learn anything new about Chris, his preferences, projects, or people in his life? If yes, call update_memory before finishing your response. Don't wait to be asked.
 - **Don't explore unprompted.** Never run tools to "orient yourself" or explore the filesystem unless Chris asks you to.
 - **Ask before big changes.** For destructive or multi-file edits, describe your plan and get confirmation before proceeding.
-- **Format for Telegram.** Use emoji as visual markers, bold key terms, and generous line breaks. Every message should be easy to scan on a phone. Follow the formatting patterns in your VOICE.md identity file.`;
+- **Format for Telegram.** Use visual markers, bold key terms, and generous line breaks. Every message should be easy to scan on a phone. Follow the formatting patterns in your identity and memory files.`;
 
   return section;
 }

--- a/tests/memory-guard.test.ts
+++ b/tests/memory-guard.test.ts
@@ -27,6 +27,10 @@ vi.mock("../src/domain/memory/recall.js", () => ({
   recallMemory: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("../src/domain/memory/voyage-index.js", () => ({
+  updateVoyageEntry: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("fs/promises", () => ({
   mkdir: vi.fn().mockResolvedValue(undefined),
   writeFile: vi.fn().mockResolvedValue(undefined),
@@ -38,6 +42,7 @@ import {
   resetGlobalBucket,
   setGlobalBucketClock,
 } from "../src/domain/memory/update-service.js";
+import { updateVoyageEntry } from "../src/domain/memory/voyage-index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -70,6 +75,7 @@ beforeEach(() => {
   // Restore real Date.now clock and reset bucket to full
   setGlobalBucketClock(() => Date.now());
   resetGlobalBucket();
+  vi.mocked(updateVoyageEntry).mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -77,6 +83,18 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("global token bucket", () => {
+  it("updates the Voyage index after writing a local recall file", async () => {
+    const result = await callUpdate("preferences", "Chris prefers concise updates");
+    expect(result).toBe("Memory updated (preferences/add)");
+    expect(updateVoyageEntry).toHaveBeenCalledOnce();
+    expect(updateVoyageEntry).toHaveBeenCalledWith(expect.objectContaining({
+      filename: expect.stringMatching(/^preferences_\d{4}-\d{2}-\d{2}_/),
+      filePath: expect.stringContaining("/tmp/test-memory/preferences_"),
+      description: "Chris prefers concise updates",
+      type: "feedback",
+    }));
+  });
+
   it("allows the first 10 calls across distinct categories", async () => {
     // Capacity is 10 — first 10 should all succeed.
     const results: string[] = [];

--- a/tests/memory-health.test.ts
+++ b/tests/memory-health.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { REQUIRED_MEMORY_FILES } from "../src/domain/memory/constants.js";
+import { checkMemoryHealth, type MemoryHealthClient } from "../src/domain/memory/health.js";
+
+function contentResponse(content: string) {
+  return {
+    data: {
+      type: "file",
+      size: Buffer.byteLength(content, "utf-8"),
+      content: Buffer.from(content).toString("base64"),
+    },
+  };
+}
+
+function client(args: {
+  contents: Record<string, string | 404>;
+  commits?: Record<string, string>;
+}): MemoryHealthClient {
+  return {
+    repos: {
+      getContent: vi.fn(async ({ path }) => {
+        const value = args.contents[path];
+        if (value === 404 || value === undefined) {
+          const err: any = new Error("not found");
+          err.status = 404;
+          throw err;
+        }
+        return contentResponse(value);
+      }),
+      listCommits: vi.fn(async ({ path }) => ({
+        data: args.commits?.[path]
+          ? [{ commit: { committer: { date: args.commits[path] } } }]
+          : [],
+      })),
+    },
+  };
+}
+
+describe("checkMemoryHealth", () => {
+  it("reports all canonical files present and non-stale", async () => {
+    const contents = Object.fromEntries(REQUIRED_MEMORY_FILES.map((path) => [path, `# ${path}`]));
+    const commits = Object.fromEntries(REQUIRED_MEMORY_FILES.map((path) => [path, "2026-05-01T00:00:00Z"]));
+
+    const report = await checkMemoryHealth({
+      client: client({ contents, commits }),
+      owner: "owner",
+      repo: "memory",
+      now: new Date("2026-05-05T00:00:00Z"),
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.missing).toHaveLength(0);
+    expect(report.empty).toHaveLength(0);
+    expect(report.stale).toHaveLength(0);
+    expect(report.files.map((f) => f.path)).toEqual([...REQUIRED_MEMORY_FILES]);
+  });
+
+  it("fails missing and empty required runtime files", async () => {
+    const contents = Object.fromEntries(REQUIRED_MEMORY_FILES.map((path) => [path, `# ${path}`]));
+    contents["SOUL.md"] = 404;
+    contents["USER.md"] = "   \n";
+
+    const report = await checkMemoryHealth({
+      client: client({ contents }),
+      owner: "owner",
+      repo: "memory",
+      now: new Date("2026-05-05T00:00:00Z"),
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.missing.map((f) => f.path)).toEqual(["SOUL.md"]);
+    expect(report.empty.map((f) => f.path)).toEqual(["USER.md"]);
+  });
+
+  it("warns when refreshable memory files are older than 30 days", async () => {
+    const contents = Object.fromEntries(REQUIRED_MEMORY_FILES.map((path) => [path, `# ${path}`]));
+    const commits = Object.fromEntries(REQUIRED_MEMORY_FILES.map((path) => [path, "2026-03-01T00:00:00Z"]));
+
+    const report = await checkMemoryHealth({
+      client: client({ contents, commits }),
+      owner: "owner",
+      repo: "memory",
+      now: new Date("2026-05-05T00:00:00Z"),
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.stale.map((f) => f.path)).toEqual([
+      "USER.md",
+      "memory/SUMMARY.md",
+      "memory/DASHBOARD.md",
+      "memory/learnings.md",
+    ]);
+    expect(report.files.find((f) => f.path === "SOUL.md")?.status).toBe("present");
+    expect(report.files.find((f) => f.path === "IDENTITY.md")?.status).toBe("present");
+  });
+});
+

--- a/tests/memory-schema.test.ts
+++ b/tests/memory-schema.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  IDENTITY_FILES,
+  KNOWLEDGE_FILES,
+  MEMORY_CATEGORY_FILES,
+  MEMORY_DIRECTORIES,
+  MEMORY_FILE_ALIASES,
+  MEMORY_FILES,
+  REQUIRED_MEMORY_FILES,
+} from "../src/domain/memory/constants.js";
+
+describe("canonical memory schema", () => {
+  it("keeps required runtime files in prompt-loader order", () => {
+    expect([...REQUIRED_MEMORY_FILES]).toEqual([
+      ...IDENTITY_FILES,
+      ...KNOWLEDGE_FILES,
+      ...MEMORY_FILES,
+    ]);
+    expect([...REQUIRED_MEMORY_FILES]).toEqual([
+      "SOUL.md",
+      "IDENTITY.md",
+      "USER.md",
+      "memory/SUMMARY.md",
+      "memory/DASHBOARD.md",
+      "memory/learnings.md",
+    ]);
+  });
+
+  it("uses runtime files for user-facing aliases", () => {
+    expect(MEMORY_FILE_ALIASES).toEqual({
+      soul: "SOUL.md",
+      identity: "IDENTITY.md",
+      user: "USER.md",
+      summary: "memory/SUMMARY.md",
+      dashboard: "memory/DASHBOARD.md",
+      learnings: "memory/learnings.md",
+    });
+  });
+
+  it("maps all update_memory categories to canonical runtime files", () => {
+    expect(MEMORY_CATEGORY_FILES).toEqual({
+      "about-chris": "USER.md",
+      preferences: "USER.md",
+      projects: "USER.md",
+      people: "USER.md",
+      decisions: "memory/learnings.md",
+      learnings: "memory/learnings.md",
+    });
+  });
+
+  it("documents expected memory directories", () => {
+    expect([...MEMORY_DIRECTORIES]).toEqual([
+      "journal/",
+      "archive/",
+      "conversations/summaries/",
+      "skills/",
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Align memory docs, CLI output, dashboard memory listing, and Telegram /memory with the runtime schema from #111.
- Add canonical memory health diagnostics for chris doctor, covering missing, empty, stale, size, and last commit data.
- Update update_memory local recall writes so new local memory files update the Voyage in-memory index immediately.

## User-facing behavior change
- chris memory, chris identity, dashboard memory, Telegram /memory, and docs now agree on the canonical runtime files: SOUL.md, IDENTITY.md, USER.md, memory/SUMMARY.md, memory/DASHBOARD.md, and memory/learnings.md.
- chris doctor now reports actionable memory schema health instead of checking the stale identity/SOUL.md path.
- New update_memory entries become available to semantic recall without restarting the bot when Voyage is configured.

## Tests run
- npm run typecheck
- npm test
- npm run docs:build

## Manual acceptance checklist
- [x] Runtime prompt loading, docs, dashboard memory list, chris memory, Telegram /memory, and chris doctor use the canonical memory schema.
- [x] chris doctor reports missing, empty, and stale memory files with remediation hints.
- [x] update_memory local recall dual-write calls updateVoyageEntry for the newly written file.
- [x] Docs build with the runtime-accurate memory schema.

Closes #111.
Part of #115.