### PR TITLE
recovery: make memory recall provider-wide

### DIFF
--- a/scripts/manual-memory-recall-checklist.md
+++ b/scripts/manual-memory-recall-checklist.md
@@ -1,0 +1,33 @@
+# Manual Memory Recall Checklist
+
+Use this checklist for issue #112 / tracker #115 after `npm run typecheck` and `npm test` pass.
+
+Run each prompt once in every provider mode:
+
+- `chris model set claude`
+- `chris model set gpt5`
+- `chris model set codex-agent`
+
+## Fixed Prompts
+
+1. `what do you remember about me?`
+   - Expected: answers as Chris Assistant, mentions persistent memory, and uses stored facts without saying it needs to search first.
+
+2. `what did we discuss recently?`
+   - Expected: uses recent conversation summaries or journal context and gives dated or relative continuity when available.
+
+3. `what should you remember about my trading agent work?`
+   - Expected: recalls relevant project memory if present and connects it to the current assistant/product context.
+
+4. `who are you, and what memory do you have?`
+   - Expected: identifies as Chris Assistant, not Claude Code/Codex/OpenAI, and describes memory, journal, summaries, and provider tools.
+
+5. `debug yourself: why might memory feel inconsistent?`
+   - Expected: can explain the active provider mode and confirm memory recall is injected at the provider prompt layer.
+
+## Pass Criteria
+
+- Claude, OpenAI Responses, and Codex Agent all show equivalent access to identity, curated memory, recent summaries, recalled memories, and current date/time context.
+- Claude custom MCP tools still appear available in Claude mode.
+- No provider answers as its substrate identity.
+- No prompt inspection or debug output exposes raw secrets or OAuth tokens.

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -19,7 +19,6 @@ import { getWorkspaceRoot } from "../tools/files.js";
 import { formatHistoryForPrompt } from "../conversation.js";
 import type { Provider, ImageAttachment } from "./types.js";
 import { recordUsage } from "../usage-tracker.js";
-import { findRelevantMemories, formatRecalledMemories } from "../domain/memory/recall.js";
 import * as os from "os";
 import * as path from "path";
 
@@ -138,25 +137,7 @@ export function createClaudeProvider(model: string): Provider {
         tools: getCustomMcpTools(),
       });
 
-      // Fire memory recall + prompt load concurrently — recall is a cheap
-      // Sonnet side-call (~500 tokens in, ~50 out) that selects which local
-      // memory files are relevant to this query.
-      const [appendPromptBase, recalledMemories] = await Promise.all([
-        getClaudeAppendPrompt(),
-        findRelevantMemories(userMessage).catch((e) => {
-          console.warn("[claude] Memory recall failed:", e instanceof Error ? e.message : e);
-          return [];
-        }),
-      ]);
-
-      // Inject recalled memories into the append prompt
-      const recalledSection = formatRecalledMemories(recalledMemories);
-      const appendPrompt = recalledSection
-        ? `${appendPromptBase}\n\n---\n\n${recalledSection}`
-        : appendPromptBase;
-      if (recalledMemories.length > 0) {
-        console.log("[claude] Recalled %d memories for chatId=%d", recalledMemories.length, chatId);
-      }
+      const appendPrompt = await getClaudeAppendPrompt(userMessage);
 
       const thinkingTokens = getThinkingTokens(userMessage);
 

--- a/src/providers/codex-agent.ts
+++ b/src/providers/codex-agent.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { resolveCodexBinary } from "../codex.js";
 import { getThreadId, setThreadId } from "../codex-sessions.js";
 import { getWorkspaceRoot } from "../tools/files.js";
-import { getCodexSystemPrompt, invalidatePromptCache } from "./shared.js";
+import { getCodexSystemPrompt, getRecalledMemoryPrompt, invalidatePromptCache } from "./shared.js";
 import type { ImageAttachment, Provider } from "./types.js";
 
 const activeControllers = new Map<number, AbortController>();
@@ -75,7 +75,14 @@ export function createCodexAgentProvider(model: string): Provider {
       const imageNote = images && images.length > 0
         ? `[${images.length} image(s) were attached, but this Codex agent mode is running text-only here. The user's caption follows.]\n\n`
         : "";
-      const systemContext = existingThreadId ? "" : `<system>\n${await getCodexSystemPrompt()}\n</system>\n\n`;
+      const recalledContext = existingThreadId
+        ? await getRecalledMemoryPrompt(userMessage, "codex-agent")
+        : "";
+      const systemContext = existingThreadId
+        ? recalledContext
+          ? `<system>\n${recalledContext}\n</system>\n\n`
+          : ""
+        : `<system>\n${await getCodexSystemPrompt(userMessage)}\n</system>\n\n`;
       const prompt = `${systemContext}${imageNote}${userMessage}`;
 
       let latestText = "";

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -195,7 +195,7 @@ export function createOpenAiProvider(model: string): Provider {
       const accessToken = await getValidAccessToken();
       const accountId = getAccountId();
 
-      const systemPrompt = await getSystemPrompt();
+      const systemPrompt = await getSystemPrompt(userMessage);
       const conversationContext = await formatHistoryForPrompt(chatId);
 
       const fullUserMessage = conversationContext

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -6,6 +6,7 @@ import { config } from "../config.js";
 import { resetLoopDetection } from "../tools/index.js";
 import { getWorkspaceRoot, isProjectActive, setWorkspaceChangeCallback } from "../tools/files.js";
 import { LIMITS } from "../infra/config/limits.js";
+import { findRelevantMemories, formatRecalledMemories } from "../domain/memory/recall.js";
 
 let cachedSystemPrompt: string | null = null;
 let lastPromptLoad = 0;
@@ -50,6 +51,7 @@ interface PromptAssembly {
   runtimeContext: string;
   providerAdapter: string;
   formatting: string;
+  currentDateTime: string;
   projectContext: string;
 }
 
@@ -188,6 +190,7 @@ function assemblePromptSections(memory: LoadedMemory, mode: PromptProviderMode, 
     runtimeContext: buildRuntimeContextSection(model, provider),
     providerAdapter: buildProviderAdapterSection(mode),
     formatting: buildFormattingSection(),
+    currentDateTime: currentDateTimeSection(),
     projectContext: buildProjectContextSection(bootstrap),
   };
 }
@@ -249,6 +252,7 @@ export async function inspectPrompt(): Promise<string> {
       { name: "Runtime Context", present: true, chars: sections.runtimeContext.length },
       { name: "Provider Adapter", present: true, chars: sections.providerAdapter.length },
       { name: "Formatting", present: true, chars: sections.formatting.length },
+      { name: "Current Date & Time", present: true, chars: sections.currentDateTime.length },
       { name: "Project Context", present: !!sections.projectContext, chars: sections.projectContext.length },
     ],
   });
@@ -310,7 +314,7 @@ Triggers for each category:
   return section;
 }
 
-export async function getSystemPrompt(): Promise<string> {
+export async function getSystemPrompt(userMessage?: string): Promise<string> {
   const now = Date.now();
   if (!cachedSystemPrompt || now - lastPromptLoad > PROMPT_CACHE_MS) {
     console.log("[prompt] Loading memory from GitHub...");
@@ -325,12 +329,13 @@ export async function getSystemPrompt(): Promise<string> {
       sections.runtimeContext,
       sections.providerAdapter,
       sections.formatting,
+      sections.currentDateTime,
       sections.projectContext,
     ]);
     lastPromptLoad = now;
     console.log("[prompt] System prompt loaded (%d chars)", cachedSystemPrompt.length);
   }
-  return cachedSystemPrompt;
+  return appendRecalledMemoryContext(cachedSystemPrompt, userMessage, "openai");
 }
 
 export function invalidatePromptCache(): void {
@@ -356,10 +361,39 @@ let lastCodexPromptLoad = 0;
  * knowledge, and Telegram formatting rules, but skips the capabilities
  * section since Claude Code's preset already handles tool descriptions.
  */
-export async function getClaudeAppendPrompt(): Promise<string> {
+export async function getRecalledMemoryPrompt(userMessage: string, providerLabel: string): Promise<string> {
+  if (!userMessage.trim()) return "";
+
+  const recalledMemories = await findRelevantMemories(userMessage).catch((e) => {
+    console.warn("[%s] Memory recall failed: %s", providerLabel, e instanceof Error ? e.message : e);
+    return [];
+  });
+
+  const recalledSection = formatRecalledMemories(recalledMemories);
+  if (recalledMemories.length > 0) {
+    console.log("[%s] Recalled %d memories for current turn", providerLabel, recalledMemories.length);
+  }
+
+  return recalledSection;
+}
+
+async function appendRecalledMemoryContext(
+  basePrompt: string,
+  userMessage: string | undefined,
+  providerLabel: string,
+): Promise<string> {
+  if (!userMessage) return basePrompt;
+
+  const recalledSection = await getRecalledMemoryPrompt(userMessage, providerLabel);
+  return recalledSection
+    ? joinPromptSections([basePrompt, recalledSection])
+    : basePrompt;
+}
+
+export async function getClaudeAppendPrompt(userMessage?: string): Promise<string> {
   const now = Date.now();
   if (cachedClaudeAppendPrompt && now - lastClaudePromptLoad < PROMPT_CACHE_MS) {
-    return cachedClaudeAppendPrompt;
+    return appendRecalledMemoryContext(cachedClaudeAppendPrompt, userMessage, "claude");
   }
 
   console.log("[prompt] Loading memory for Claude append prompt...");
@@ -377,13 +411,13 @@ export async function getClaudeAppendPrompt(): Promise<string> {
   lastClaudePromptLoad = now;
   console.log("[prompt] Claude append prompt loaded (%d chars)", cachedClaudeAppendPrompt.length);
 
-  return cachedClaudeAppendPrompt;
+  return appendRecalledMemoryContext(cachedClaudeAppendPrompt, userMessage, "claude");
 }
 
-export async function getCodexSystemPrompt(): Promise<string> {
+export async function getCodexSystemPrompt(userMessage?: string): Promise<string> {
   const now = Date.now();
   if (cachedCodexSystemPrompt && now - lastCodexPromptLoad < PROMPT_CACHE_MS) {
-    return cachedCodexSystemPrompt;
+    return appendRecalledMemoryContext(cachedCodexSystemPrompt, userMessage, "codex-agent");
   }
 
   console.log("[prompt] Loading memory for Codex system prompt...");
@@ -397,10 +431,11 @@ export async function getCodexSystemPrompt(): Promise<string> {
     sections.runtimeContext,
     sections.providerAdapter,
     sections.formatting,
+    sections.currentDateTime,
     sections.projectContext,
   ]);
   lastCodexPromptLoad = now;
   console.log("[prompt] Codex system prompt loaded (%d chars)", cachedCodexSystemPrompt.length);
 
-  return cachedCodexSystemPrompt;
+  return appendRecalledMemoryContext(cachedCodexSystemPrompt, userMessage, "codex-agent");
 }

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -10,12 +10,17 @@ const fixtures = vi.hoisted(() => {
     curatedSummary: "Chris is rebuilding confidence in his personal assistant.",
     skillIndex: "- **debug_self** - Inspect assistant runtime\n  Triggers: \"debug yourself\"",
   };
+  const recalledMemory = {
+    path: "/Users/christaylor/Projects/chris-assistant/memory/trading-agent.md",
+    mtimeMs: Date.UTC(2026, 4, 5),
+    content: "Chris is building My Trading Agent and wants continuity across providers.",
+  };
 
   const config = {
     model: "gpt-5.2",
   };
 
-  return { memory, config };
+  return { memory, recalledMemory, config };
 });
 
 vi.mock("../src/config.js", () => ({
@@ -37,6 +42,13 @@ vi.mock("../src/memory/loader.js", () => ({
   ].filter(Boolean).join("\n\n---\n\n")),
 }));
 
+vi.mock("../src/domain/memory/recall.js", () => ({
+  findRelevantMemories: vi.fn(async () => [fixtures.recalledMemory]),
+  formatRecalledMemories: vi.fn((memories: typeof fixtures.recalledMemory[]) => memories.length
+    ? `# Recalled Memories\n\n### trading-agent.md\n${memories[0].content}`
+    : ""),
+}));
+
 vi.mock("../src/tools/files.js", () => ({
   getWorkspaceRoot: vi.fn(() => "/Users/christaylor/Projects/chris-assistant"),
   isProjectActive: vi.fn(() => true),
@@ -55,18 +67,18 @@ import {
   invalidatePromptCache,
 } from "../src/providers/shared.js";
 
-async function assembledPrompts(): Promise<string[]> {
+async function assembledPrompts(userMessage?: string): Promise<string[]> {
   fixtures.config.model = "gpt-5.2";
   invalidatePromptCache();
-  const openai = await getSystemPrompt();
+  const openai = await getSystemPrompt(userMessage);
 
   fixtures.config.model = "claude-sonnet-4-6";
   invalidatePromptCache();
-  const claude = await getClaudeAppendPrompt();
+  const claude = await getClaudeAppendPrompt(userMessage);
 
   fixtures.config.model = "codex-agent-o4-mini";
   invalidatePromptCache();
-  const codex = await getCodexSystemPrompt();
+  const codex = await getCodexSystemPrompt(userMessage);
 
   return [openai, claude, codex];
 }
@@ -115,6 +127,36 @@ describe("assistant runtime prompt contract", () => {
     expect(prompt).toContain("Tools Available");
   });
 
+  it("assembles identity, curated memory, recent summaries, recalled memories, and current time for every provider", async () => {
+    for (const prompt of await assembledPrompts("what should you remember about my trading agent?")) {
+      expect(prompt).toContain("Chris Assistant is warm, direct, and continuous.");
+      expect(prompt).toContain("Chris is rebuilding confidence in his personal assistant.");
+      expect(prompt).toContain("Discussed recovery planning.");
+      expect(prompt).toContain("# Recalled Memories");
+      expect(prompt).toContain("Chris is building My Trading Agent");
+      expect(prompt).toContain("# Current Date & Time");
+      expect(prompt).toContain("Europe/London");
+    }
+  });
+
+  it("adds recalled memories even when the base provider prompt is cached", async () => {
+    await getSystemPrompt();
+    const openai = await getSystemPrompt("what should you remember about my trading agent?");
+    expect(openai).toContain("# Recalled Memories");
+
+    fixtures.config.model = "claude-sonnet-4-6";
+    invalidatePromptCache();
+    await getClaudeAppendPrompt();
+    const claude = await getClaudeAppendPrompt("what should you remember about my trading agent?");
+    expect(claude).toContain("# Recalled Memories");
+
+    fixtures.config.model = "codex-agent-o4-mini";
+    invalidatePromptCache();
+    await getCodexSystemPrompt();
+    const codex = await getCodexSystemPrompt("what should you remember about my trading agent?");
+    expect(codex).toContain("# Recalled Memories");
+  });
+
   it("suppresses provider identity leakage for Claude and Codex agent modes", async () => {
     fixtures.config.model = "claude-sonnet-4-6";
     invalidatePromptCache();
@@ -151,6 +193,7 @@ describe("prompt inspection", () => {
       "Runtime Context",
       "Provider Adapter",
       "Formatting",
+      "Current Date & Time",
       "Project Context",
     ]) {
       expect(report).toContain(section);


### PR DESCRIPTION
## Summary

- Move per-turn memory recall into shared provider prompt assembly so Claude, OpenAI Responses, and Codex Agent receive the same recalled-memory context.
- Keep Claude custom MCP behavior intact while routing its recalled-memory prompt through the shared helper.
- Inject recalled memory into Codex Agent resumed threads, where the base system prompt is not resent.
- Add prompt contract coverage for identity, curated memory, recent summaries, recalled memories, current date/time, and cached base prompt behavior.
- Add a manual memory recollection checklist for provider-by-provider acceptance testing.

## User-facing behavior change

Chris Assistant should now use relevant stored facts consistently in normal chat regardless of whether the active provider is Claude, OpenAI Responses, or Codex Agent. Memory recall is product-level behavior rather than Claude-only behavior.

## Tests run

- `npm test -- tests/prompt-contract.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run chris -- prompt inspect`
- `git diff --check`
- `npm run docs:build`

## Manual acceptance checklist

- Run the prompts in `scripts/manual-memory-recall-checklist.md` across Claude, OpenAI Responses, and Codex Agent.
- Confirm each provider answers as Chris Assistant and uses identity, curated memory, recent summaries, recalled memories, and current date/time context.
- Confirm Claude custom MCP tools still appear available in Claude mode.
- Confirm prompt inspection/debug output does not expose raw secrets or OAuth tokens.

Closes #112.
Part of #115.
