### PR TITLE
fix: gate memory recall for generic prompts

### DIFF
--- a/src/domain/memory/recall.ts
+++ b/src/domain/memory/recall.ts
@@ -36,6 +36,8 @@ export interface RelevantMemory {
   content: string;
 }
 
+type RecallIntent = "none" | "personal" | "project";
+
 // ---------------------------------------------------------------------------
 // Memory directory
 // ---------------------------------------------------------------------------
@@ -84,6 +86,11 @@ export async function findRelevantMemories(
   query: string,
   memoryDir: string = LOCAL_MEMORY_DIR,
 ): Promise<RelevantMemory[]> {
+  const intent = recallIntent(query);
+  if (intent === "none") {
+    return [];
+  }
+
   const memories = await scanMemoryFiles(memoryDir);
   if (memories.length === 0) {
     return [];
@@ -93,13 +100,14 @@ export async function findRelevantMemories(
   let selected: MemoryHeader[];
   if (isVoyageReady()) {
     selected = await semanticRecall(query);
+    selected = filterMemoriesByIntent(query, selected, intent);
     if (selected.length === 0) {
-      // Voyage returned nothing — fall back to keyword scorer
-      console.log("[recall] Voyage returned 0 results, falling back to keyword scoring");
-      selected = selectRelevantMemories(query, memories);
+      // Voyage returned nothing usable for this turn — fall back to keyword scorer.
+      console.log("[recall] Semantic recall yielded no relevant results, falling back to keyword scoring");
+      selected = selectRelevantMemories(query, memories, intent);
     }
   } else {
-    selected = selectRelevantMemories(query, memories);
+    selected = selectRelevantMemories(query, memories, intent);
   }
 
   if (selected.length === 0) {
@@ -171,6 +179,48 @@ const TIME_PATTERNS = [
   /\b\d{4}-\d{2}-\d{2}\b/,
 ];
 
+const EXPLICIT_MEMORY_PATTERNS = [
+  /\b(?:remember|recall|memory|memories|know about me|about me)\b/i,
+  /\b(?:what|who)\s+(?:do|did)\s+you\s+(?:remember|know)\b/i,
+  /\b(?:what|when)\s+(?:did|were|was)\s+(?:we|i|you)\b/i,
+  /\b(?:talked?\s+about|discussed?|worked?\s+on|happened)\b/i,
+  /\b(?:yesterday|last\s+week|last\s+month|recently|previously|earlier)\b/i,
+  /\bdebug yourself\b/i,
+];
+
+const PROJECT_CONTEXT_PATTERNS = [
+  /\b(?:my|our|this|the)\s+(?:project|repo|repository|codebase|app|agent|assistant|bot)\b/i,
+  /\b(?:project|repo|repository|codebase|issue|pr|pull request|branch|sprint)\s+(?:we|i|you|chris)\b/i,
+  /\bchris-assistant\b/i,
+  /\btrading agent\b/i,
+];
+
+const GENERIC_HELP_PATTERNS = [
+  /^(?:what|how|why|when|where|can|could|should|would|is|are|does|do)\b/i,
+  /\b(?:explain|define|summarize|compare|recommend|help me|show me|tell me)\b/i,
+];
+
+function recallIntent(query: string): RecallIntent {
+  const normalized = query.trim();
+  if (!normalized) return "none";
+
+  const wantsMemory = EXPLICIT_MEMORY_PATTERNS.some((p) => p.test(normalized));
+  const wantsProject = PROJECT_CONTEXT_PATTERNS.some((p) => p.test(normalized));
+  if (wantsProject) return "project";
+  if (wantsMemory) return "personal";
+
+  const tokens = tokenize(normalized);
+  if (tokens.length < 4) return "none";
+
+  // General help questions should not pull project memories just because an
+  // embedding or keyword overlaps with one remembered project.
+  if (GENERIC_HELP_PATTERNS.some((p) => p.test(normalized))) {
+    return "none";
+  }
+
+  return "personal";
+}
+
 /**
  * Extract meaningful tokens from text for scoring.
  * Lowercases, strips punctuation, removes stop words.
@@ -186,7 +236,9 @@ function tokenize(text: string): string[] {
 /**
  * Score a memory against a query using keyword overlap + bonuses.
  */
-function scoreMemory(query: string, queryTokens: string[], memory: MemoryHeader): number {
+function scoreMemory(query: string, queryTokens: string[], memory: MemoryHeader, intent: RecallIntent): number {
+  if (!memoryAllowedForIntent(query, memory, intent)) return 0;
+
   // Build searchable text from filename + description
   const memText = [memory.filename, memory.description || ""].join(" ");
   const memTokens = new Set(tokenize(memText));
@@ -233,6 +285,7 @@ function scoreMemory(query: string, queryTokens: string[], memory: MemoryHeader)
 function selectRelevantMemories(
   query: string,
   memories: MemoryHeader[],
+  intent: RecallIntent,
 ): MemoryHeader[] {
   const queryTokens = tokenize(query);
   if (queryTokens.length === 0) {
@@ -241,10 +294,10 @@ function selectRelevantMemories(
   }
 
   const scored = memories
-    .map((m) => ({ memory: m, score: scoreMemory(query, queryTokens, m) }))
-    .filter((s) => s.score > 0.15) // Minimum relevance threshold
+    .map((m) => ({ memory: m, score: scoreMemory(query, queryTokens, m, intent) }))
+    .filter((s) => s.score > 0.3) // Minimum relevance threshold
     .sort((a, b) => b.score - a.score)
-    .slice(0, 5);
+    .slice(0, intent === "project" ? 3 : 2);
 
   if (scored.length > 0) {
     console.log(
@@ -256,4 +309,29 @@ function selectRelevantMemories(
   }
 
   return scored.map((s) => s.memory);
+}
+
+function filterMemoriesByIntent(query: string, memories: MemoryHeader[], intent: RecallIntent): MemoryHeader[] {
+  return memories
+    .filter((memory) => memoryAllowedForIntent(query, memory, intent))
+    .slice(0, intent === "project" ? 3 : 2);
+}
+
+function memoryAllowedForIntent(query: string, memory: MemoryHeader, intent: RecallIntent): boolean {
+  if (intent === "none") return false;
+  if (intent === "project") return true;
+
+  if (memory.type === "project" || memory.type === "reference") {
+    return hasDirectMemoryNameOverlap(query, memory);
+  }
+
+  return true;
+}
+
+function hasDirectMemoryNameOverlap(query: string, memory: MemoryHeader): boolean {
+  const queryTokens = new Set(tokenize(query));
+  if (queryTokens.size === 0) return false;
+
+  const memoryTokens = tokenize([memory.filename, memory.description || ""].join(" "));
+  return memoryTokens.some((token) => queryTokens.has(token));
 }

--- a/tests/memory-recall.test.ts
+++ b/tests/memory-recall.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/domain/memory/voyage-index.js", () => ({
+  buildVoyageIndex: vi.fn(),
+  initVoyageKey: vi.fn(),
+  isVoyageReady: vi.fn(() => false),
+  semanticRecall: vi.fn(),
+}));
+
+import { findRelevantMemories } from "../src/domain/memory/recall.js";
+
+let memoryDir: string | null = null;
+
+async function makeMemoryDir(): Promise<string> {
+  memoryDir = await mkdtemp(join(tmpdir(), "chris-memory-recall-"));
+  return memoryDir;
+}
+
+async function writeMemory(relativePath: string, frontmatter: string, body: string): Promise<void> {
+  if (!memoryDir) throw new Error("memory dir not created");
+  const filePath = join(memoryDir, relativePath);
+  await writeFile(filePath, `---\n${frontmatter}\n---\n\n${body}`);
+}
+
+afterEach(async () => {
+  if (memoryDir) {
+    await rm(memoryDir, { recursive: true, force: true });
+    memoryDir = null;
+  }
+});
+
+describe("memory recall gating", () => {
+  it("does not inject project memories for generic technical questions", async () => {
+    const dir = await makeMemoryDir();
+    await writeMemory(
+      "trading-agent.md",
+      "type: project\ndescription: Trading Agent TypeScript service architecture and broker integration",
+      "Chris is building My Trading Agent with TypeScript services.",
+    );
+
+    const memories = await findRelevantMemories("how should I structure a TypeScript service?", dir);
+
+    expect(memories).toEqual([]);
+  });
+
+  it("allows project memories when the user asks for project continuity", async () => {
+    const dir = await makeMemoryDir();
+    await writeMemory(
+      "trading-agent.md",
+      "type: project\ndescription: Trading Agent TypeScript service architecture and broker integration",
+      "Chris is building My Trading Agent with TypeScript services.",
+    );
+
+    const memories = await findRelevantMemories("what should you remember about my trading agent work?", dir);
+
+    expect(memories).toHaveLength(1);
+    expect(memories[0]!.content).toContain("My Trading Agent");
+  });
+
+  it("keeps personal preference recall available without broad project recall", async () => {
+    const dir = await makeMemoryDir();
+    await writeMemory(
+      "concise-updates.md",
+      "type: feedback\ndescription: Chris prefers concise engineering updates",
+      "Chris prefers concise engineering updates.",
+    );
+    await writeMemory(
+      "unrelated-project.md",
+      "type: project\ndescription: Weather dashboard project and API work",
+      "A separate weather dashboard project exists.",
+    );
+
+    const memories = await findRelevantMemories("what do you know about Chris preferences?", dir);
+
+    expect(memories).toHaveLength(1);
+    expect(memories[0]!.content).toContain("concise engineering updates");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a recall-intent gate so generic help/technical prompts do not trigger memory injection.
- Filter semantic and keyword recall results by intent so project/reference memories are only injected for explicit project-continuity turns or direct project references.
- Raise keyword recall selectivity and cap injected memories to reduce unrelated context bleed.
- Add regression tests for generic technical prompts, explicit project continuity, and personal preference recall.

## User-facing behavior change

Chris Assistant should stop pulling unrelated project memories into ordinary answers that do not need memory recall. Explicit memory/project-continuity prompts still receive recalled context.

## Tests run

- `npm test -- tests/memory-recall.test.ts tests/prompt-contract.test.ts tests/voyage-index.test.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Notes

Follow-up to #112 / PR #118 after observing over-eager provider-wide recall in normal chat.
