### PR TITLE
recovery: repair docs site and relaunch documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm test
+      - run: npm run docs:build

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You send a message on Telegram
 
 The assistant has its own identity (personality, voice, rules) and an evolving memory — all stored as markdown in a separate private GitHub repo. You can browse, edit, and roll back anything it knows.
 
+For the runtime-accurate guide to what the assistant remembers, how recall works, and when to use each provider mode, see the [Operating Manual](docs/operating-manual.md).
+
 ### Multi-Provider AI
 
 Switch between providers with a single command. The model string determines the backend:
@@ -105,7 +107,7 @@ Accessible over Tailnet with token auth.
 ### Install
 
 ```bash
-git clone https://github.com/christayloruk/chris-assistant.git
+git clone https://github.com/theglove44/chris-assistant.git
 cd chris-assistant
 npm install
 npm link              # Makes 'chris' available globally

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: 'Guide', link: '/getting-started/overview' },
+      { text: 'Manual', link: '/operating-manual' },
       { text: 'Symphony', link: '/symphony-overview' },
       { text: 'Architecture', link: '/architecture/overview' },
       { text: 'Tools', link: '/tools/overview' },
@@ -21,6 +22,7 @@ export default defineConfig({
             { text: 'Overview', link: '/getting-started/overview' },
             { text: 'Setup', link: '/getting-started/setup' },
             { text: 'Usage', link: '/getting-started/usage' },
+            { text: 'Operating Manual', link: '/operating-manual' },
           ],
         },
         {
@@ -104,7 +106,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/christaylor/chris-assistant' },
+      { icon: 'github', link: 'https://github.com/theglove44/chris-assistant' },
     ],
 
     search: {

--- a/docs/architecture/design-decisions.md
+++ b/docs/architecture/design-decisions.md
@@ -13,7 +13,7 @@ The model string determines the provider. `gpt-*`/`o3*`/`o4-*` → OpenAI, `Mini
 
 `src/tools/registry.ts` — shared tool registry. Tools register once with `registerTool()`, auto-generate both OpenAI and Claude MCP formats. Generic `dispatchToolCall()` replaces per-tool if/else in providers. New tools: create file in `src/tools/`, add import to `src/tools/index.ts`, done.
 
-All providers support `update_memory`. Claude uses MCP (in-process server). OpenAI and MiniMax use OpenAI-format function calling. All delegate to the same `executeMemoryTool()` function.
+Claude, OpenAI Responses, and MiniMax support direct `update_memory` calls. Claude uses MCP (in-process server). OpenAI and MiniMax use OpenAI-format function calling. All direct writes delegate to the same `executeMemoryTool()` function. Codex Agent receives injected memory context and semantic recall, but direct memory writes are not wired into the Codex CLI subprocess yet.
 
 ## Tool Categories
 
@@ -53,7 +53,7 @@ Last 20 messages per chat stored in `~/.chris-assistant/conversations.json`. Loa
 
 ## Conversation Archive
 
-`conversation-archive.ts` appends every message (user + assistant) as a JSONL line to `~/.chris-assistant/archive/YYYY-MM-DD.jsonl` via synchronous `appendFileSync` (microseconds, never throws). Called from `addMessage()` in `conversation.ts` before the rolling window trims old messages. A periodic uploader (every 30 minutes) pushes changed archive files to the memory repo using SHA-256 dedup.
+`conversation-archive.ts` appends every message (user + assistant) as a JSONL line to `~/.chris-assistant/archive/YYYY-MM-DD.jsonl` via synchronous `appendFileSync` (microseconds, never throws). Called from `addMessage()` in `conversation.ts` before the rolling window trims old messages. A periodic uploader (every 5 minutes) pushes changed archive files to the memory repo using SHA-256 dedup.
 
 ## Daily Conversation Summaries
 

--- a/docs/architecture/internals.md
+++ b/docs/architecture/internals.md
@@ -37,7 +37,7 @@ chris-assistant-memory/       ← Separate private repo (the brain)
 ├── memory/SUMMARY.md         # Weekly-consolidated curated summary
 ├── memory/DASHBOARD.md       # Operator-facing status and notes
 ├── memory/learnings.md       # Self-improvement notes
-├── archive/YYYY-MM-DD.jsonl  # Daily JSONL message logs (uploaded every 30 minutes)
+├── archive/YYYY-MM-DD.jsonl  # Daily JSONL message logs (uploaded every 5 minutes)
 ├── journal/YYYY-MM-DD.md     # Bot's daily journal notes (uploaded every 6 hours)
 ├── conversations/summaries/YYYY-MM-DD.md  # AI-generated daily conversation summaries
 ├── conversations/channels/<name>/YYYY-WXX.md  # Weekly per-channel summaries
@@ -53,7 +53,7 @@ The bot uses `@anthropic-ai/claude-agent-sdk` as a full agent when Claude is the
 
 The system prompt uses `{ type: 'preset', preset: 'claude_code', append: <identity/memory> }` to extend Claude Code's default prompt with personality and knowledge. Session persistence via `resume` gives multi-turn conversation context without manual history management. Extended thinking is keyword-triggered ("think" → 10k tokens, "think hard" → 50k). Authenticated through Max subscription via the `claude` CLI (same auth Claude Code uses).
 
-Telegram commands: `/stop` aborts the active query via AbortController, `/session` shows the active session ID, `/clear` resets both conversation history and Claude session.
+Telegram commands: `/stop` aborts the active provider query when supported, `/session` shows the active provider session ID when available, and `/clear` resets conversation history plus the active provider session.
 
 ### OpenAI (Codex Responses API)
 
@@ -117,10 +117,10 @@ Telegram is now implemented under `src/channels/telegram/`:
 ## Conversation System
 
 ### Persistent History
-Last 20 messages per chat in `~/.chris-assistant/conversations.json`. Loaded lazily, saved async via write queue. Fire-and-forget `addMessage()`, await `clearHistory()`. Metadata (`{ source?, channelName? }`) passed through to archive. `/clear` wipes history + Claude session. `/purge` also redacts today's archive.
+Last 20 messages per chat in `~/.chris-assistant/conversations.json`. Loaded lazily, saved async via write queue. Fire-and-forget `addMessage()`, await `clearHistory()`. Metadata (`{ source?, channelName? }`) passed through to archive. `/clear` wipes history plus the active provider session. `/purge` also redacts today's archive.
 
 ### Archive
-`conversation-archive.ts` — sync `appendFileSync` to `~/.chris-assistant/archive/YYYY-MM-DD.jsonl`. Each entry has optional `source` and `channelName` fields. Uploads to GitHub every 30 minutes (SHA-256 dedup). Exports: `readLocalArchive()`, `listLocalArchiveDates()`, `datestamp()`, `localArchivePath()`, `uploadArchives()`, `redactArchiveEntries()`.
+`conversation-archive.ts` — sync `appendFileSync` to `~/.chris-assistant/archive/YYYY-MM-DD.jsonl`. Each entry has optional `source` and `channelName` fields. Uploads to GitHub every 5 minutes (SHA-256 dedup). Exports: `readLocalArchive()`, `listLocalArchiveDates()`, `datestamp()`, `localArchivePath()`, `uploadArchives()`, `redactArchiveEntries()`.
 
 ### Daily Summaries
 `conversation-summary.ts` — fires at 23:55 local time. Reads today's archive, calls `chat()` with summarization prompt, writes to `conversations/summaries/YYYY-MM-DD.md` in memory repo. Backfills yesterday on startup if missing.
@@ -135,7 +135,7 @@ Last 20 messages per chat in `~/.chris-assistant/conversations.json`. Loaded laz
 `conversation-backup.ts` — backs up `conversations.json` to GitHub every 6 hours (SHA-256 dedup). Immediate backup on startup.
 
 ### Purge
-`/purge` clears rolling window, resets Claude session, redacts today's archive entries, writes empty file so GitHub copy gets overwritten, triggers immediate upload.
+`/purge` clears the rolling window, resets the active provider session, redacts today's archive entries, writes an empty file so the GitHub copy gets overwritten, and triggers immediate upload.
 
 ## Tool Details
 
@@ -161,7 +161,7 @@ Native fetch, 15s timeout. HTML extracted via Readability + linkedom, regex fall
 `git_status`, `git_diff` (optional `staged`), `git_commit` (optional `files` array). No `git_push` (safety). 50KB diff truncation.
 
 ### Memory Tool
-All providers support `update_memory`. Claude via MCP, OpenAI/MiniMax via function calling. All delegate to `executeMemoryTool()`.
+Claude, OpenAI Responses, and MiniMax support direct `update_memory` calls. Claude uses MCP, OpenAI/MiniMax use function calling, and all direct writes delegate to `executeMemoryTool()`. Codex Agent receives injected memory context and semantic recall, but direct memory writes are not wired into the Codex CLI subprocess yet.
 
 ### Market Snapshot
 SSHes to Mac Mini (via `MAC_MINI_HOST` env var or SSH config alias) to run `tasty-coach --snapshot --json`. Parses JSON output into structured objects. Formats for Telegram with categorized sections (Futures, ETFs, Commodities, Crypto, Volatility) and auto-generated insights.

--- a/docs/development/local-dev.md
+++ b/docs/development/local-dev.md
@@ -11,21 +11,16 @@ description: Development workflow, adding tools, and adding providers
 npm run dev              # Run bot with tsx watch (auto-reload on changes)
 npm run typecheck        # TypeScript type checking (includes esbuild compat check)
 npm test                 # Run Vitest test suite
+npm run docs:build       # Build docs, prepare deep-route aliases, and smoke-test routes
 npx tsx src/cli/index.ts # Run CLI directly without global install
 npm run setup:calendar-helper # Build/install macOS Calendar helper app (~/.chris-assistant/ChrisCalendar.app)
 ```
 
 ## Test Suite
 
-vitest suite in `tests/`:
+Vitest suite in `tests/` covers markdown rendering, workspace path guards, provider routing, prompt contracts, memory recall, Symphony workflow behavior, Telegram handlers, and more.
 
-| File | Tests | Coverage |
-|------|-------|----------|
-| `markdown.test.ts` | 29 | Telegram MarkdownV2 conversion |
-| `path-guard.test.ts` | 10 | Workspace path boundary enforcement |
-| `loop-detection.test.ts` | 9 | Tool loop breaker |
-
-CI via `.github/workflows/ci.yml` runs typecheck + tests on push/PR to main.
+CI via `.github/workflows/ci.yml` runs typecheck, tests, and `npm run docs:build` on push/PR to main.
 
 ::: tip Test environment
 Test files set dummy env vars before imports to avoid `config.ts` throwing on missing required variables.
@@ -35,7 +30,7 @@ Test files set dummy env vars before imports to avoid `config.ts` throwing on mi
 
 1. Create `src/tools/<name>.ts` with a `registerTool()` call
 2. Add `import "./<name>.js"` to `src/tools/index.ts`
-3. All three providers pick it up automatically — no provider code changes needed
+3. Shared-tool providers pick it up automatically. Codex Agent currently gets injected assistant context but not these custom tools directly inside the Codex CLI subprocess.
 
 The tool registry auto-generates both OpenAI and Claude MCP format definitions from a single registration.
 
@@ -61,3 +56,5 @@ The codebase follows a convention-over-configuration approach:
 
 1. `tsc --noEmit` — standard TypeScript type checking
 2. `node scripts/check-esbuild-compat.js` — scans for `</` inside regex literals (esbuild misparses these as HTML closing tags)
+
+`npm run docs:build` runs VitePress, creates `page/index.html` aliases for extensionless deep links, and verifies representative deep routes render their own page title instead of the home page fallback.

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -18,9 +18,9 @@ Message your bot on Telegram or Discord. That's it. On first contact, the assist
 | Command | Description |
 |---------|-------------|
 | `/start` | Initial greeting |
-| `/clear` | Reset conversation history and Claude session (long-term memory is preserved) |
-| `/stop` | Abort the current Claude query |
-| `/session` | Show active Claude session info |
+| `/clear` | Reset conversation history and active provider session (long-term memory is preserved) |
+| `/stop` | Abort the current provider query when supported |
+| `/session` | Show active provider session info when available |
 | `/model` | Show current AI model and provider |
 | `/memory` | Show memory file status with sizes |
 | `/project` | Show or set the active project/workspace directory |
@@ -38,7 +38,7 @@ Message your bot on Telegram or Discord. That's it. On first contact, the assist
 
 ## Conversation Archive & Recall
 
-Every message (user and assistant) is archived as JSONL to `~/.chris-assistant/archive/YYYY-MM-DD.jsonl`. These archives are uploaded to the GitHub memory repo every 5 minutes.
+Every message (user and assistant) is archived as JSONL to `~/.chris-assistant/archive/YYYY-MM-DD.jsonl`. These archives are uploaded to the GitHub memory repo every 5 minutes with SHA-256 deduping.
 
 At 23:55 each day, an AI-generated summary of the day's conversations is created and stored in the memory repo. The last 7 days of summaries are automatically loaded into the system prompt, giving the bot natural recall of recent conversations.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,11 @@ hero:
       text: Get Started
       link: /getting-started/overview
     - theme: alt
+      text: Operating Manual
+      link: /operating-manual
+    - theme: alt
       text: See Symphony
       link: /symphony-overview
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/christaylor/chris-assistant
 
 features:
   - title: Multi-Provider AI

--- a/docs/operating-manual.md
+++ b/docs/operating-manual.md
@@ -1,0 +1,111 @@
+---
+title: Operating Manual
+description: How Chris Assistant remembers, recalls, and chooses provider modes
+---
+
+# Operating Manual
+
+This page describes the shipped assistant behavior. Roadmap ideas live under [Roadmap](/roadmap/features); this manual is for what the runtime does now.
+
+## What It Remembers
+
+Chris Assistant has three layers of memory:
+
+| Layer | Where it lives | What it is for |
+|-------|----------------|----------------|
+| Short-term conversation history | `~/.chris-assistant/conversations.json` | Last 20 messages per chat, used for immediate continuity |
+| Long-term memory | Private GitHub memory repo | Durable facts about Chris, projects, preferences, decisions, and learnings |
+| Local archives and summaries | `~/.chris-assistant/archive/` plus GitHub summaries | Conversation recall beyond the rolling 20-message window |
+
+The core GitHub memory files are `SOUL.md`, `IDENTITY.md`, `USER.md`, `memory/SUMMARY.md`, `memory/DASHBOARD.md`, and `memory/learnings.md`. The assistant also writes daily journal notes and generates conversation summaries.
+
+## How Recall Works
+
+Every normal provider prompt includes the assistant identity, curated memory, recent summaries, current date/time, and relevant recalled memory.
+
+Semantic recall uses Voyage AI when `VOYAGE_API_KEY` is configured. The runtime embeds memory files and injects the most relevant matches for the current user message. If Voyage is unavailable or returns no strong matches, recall falls back to keyword and recency scoring.
+
+Recent conversation summaries are always available in the prompt. Older local recall files can be surfaced by semantic recall when they match the current question.
+
+## How To Inspect Memory
+
+Use the assistant directly:
+
+```text
+what do you remember about me?
+what did we discuss recently?
+debug yourself
+```
+
+Use Telegram:
+
+| Command | What it shows |
+|---------|---------------|
+| `/memory` | Required memory files and sizes |
+| `/model` | Active provider and capability metadata |
+| `/session` | Current provider session details, when that provider has one |
+| `/reload` | Clears the system prompt cache so the next turn reloads memory |
+
+Use the CLI:
+
+```bash
+chris memory status
+chris memory show user
+chris memory search "trading agent"
+chris prompt inspect
+chris dream status
+```
+
+The dashboard also exposes memory, schedules, conversations, and runtime health when enabled.
+
+## How To Correct Memory
+
+Small corrections can be made in conversation:
+
+```text
+remember that my project deadline moved to June
+replace the note about my preferred editor: I use Cursor for most app work
+```
+
+The `update_memory` tool validates writes before they reach GitHub. It blocks oversized content, common prompt-injection phrases, dangerous shell blocks, path traversal, and too-frequent replace operations.
+
+For direct edits, use:
+
+```bash
+chris memory edit user
+chris memory edit learnings
+```
+
+Direct edits are committed to the private memory repo. Use `/reload` or wait for the 5-minute prompt cache to expire before expecting the running bot to use the new content.
+
+## Provider Modes
+
+Providers are not interchangeable. Use `/model` or `chris model` to see the current capability metadata.
+
+| Provider | Best use | Memory and tools |
+|----------|----------|------------------|
+| Claude Agent | Default personal assistant path | Memory read/write, semantic recall, journal, scheduler, custom tools, native coding tools |
+| OpenAI Responses | Personal assistant chat with OpenAI models and vision | Memory read/write, semantic recall, journal, scheduler, shared tools, image support |
+| Codex Agent | Coding-focused workspace work | Identity and recalled memory are injected, but direct memory write and journal tools are not wired into the Codex CLI subprocess |
+| MiniMax | General assistant chat through MiniMax | Memory read/write, semantic recall, journal, scheduler, shared tools, image support |
+
+Use Claude or OpenAI Responses when the job depends on the fullest personal-assistant behavior. Use Codex Agent when the job is primarily codebase work and native Codex workspace tooling is the point.
+
+## Routine Recovery Checks
+
+These prompts should feel like Chris Assistant, not a provider-branded shell:
+
+```text
+who are you?
+where do you run?
+what memory/tools do you have?
+how are you different from Claude Code?
+```
+
+For runtime diagnostics, use:
+
+```bash
+chris doctor
+chris prompt inspect
+chris codex status
+```

--- a/docs/roadmap/features.md
+++ b/docs/roadmap/features.md
@@ -30,7 +30,7 @@ Tools and features that expand what the bot can do.
 |---|--------|--------|------|-------------|
 | 1 | 🔴 | ✅ | **Streaming responses** | OpenAI and MiniMax stream via `onChunk`. Telegram edits every 1.5s with cursor. |
 | 2 | 🟠 | ✅ | **Persistent conversation history** | Last 20 messages per chat, async I/O with write queue. |
-| 3 | 🟠 | ✅ | **MarkdownV2 rendering** | Context-aware escaping, plain text fallback. |
+| 3 | 🟠 | ✅ | **Telegram HTML rendering** | Markdown-like input converted to Telegram HTML (`parse_mode: "HTML"`), with plain text fallback. |
 | 4 | 🟡 | ⬜ | **Voice message support** | Transcribe incoming voice via Whisper, optionally respond with TTS. |
 | 5 | 🟢 | ✅ | **Telegram commands menu** | `/model`, `/memory`, `/help` registered via `setMyCommands`. |
 

--- a/docs/tools/memory.md
+++ b/docs/tools/memory.md
@@ -31,7 +31,7 @@ chris-assistant-memory/
 
 ## `update_memory` Tool
 
-Registered in `src/tools/memory.ts`. All providers support it — Claude uses MCP (in-process server), OpenAI and MiniMax use OpenAI-format function calling. All delegate to the same `executeMemoryTool()` function in `src/domain/memory/update-service.ts`.
+Registered in `src/tools/memory.ts`. Claude uses MCP (in-process server), while OpenAI Responses and MiniMax use OpenAI-format function calling. Those shared-tool providers delegate to the same `executeMemoryTool()` function in `src/domain/memory/update-service.ts`. Codex Agent receives injected memory context and semantic recall, but direct memory writes are not wired into the Codex CLI subprocess yet.
 
 ### Actions
 

--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -55,7 +55,7 @@ Skills are higher-level — they're JSON definitions that compose existing tools
 
 1. Create `src/tools/<name>.ts` with a `registerTool()` call
 2. Add `import "./<name>.js"` to `src/tools/index.ts`
-3. All three providers pick it up automatically — no provider code changes needed
+3. Shared-tool providers pick it up automatically. Codex Agent currently receives memory context but does not get these custom tools directly inside the Codex CLI subprocess.
 
 ## Loop Detection
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "setup:reminders-helper": "bash scripts/setup-reminders-helper.sh",
     "test": "vitest run",
     "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
+    "docs:build": "vitepress build docs && node scripts/prepare-docs-routes.js && node scripts/check-docs-routes.js",
     "docs:preview": "vitepress preview docs",
-    "docs:deploy": "vitepress build docs && rsync -avz --delete docs/.vitepress/dist/ ${DOCS_DEPLOY_HOST:?Set DOCS_DEPLOY_HOST}:~/chris-assistant-docs/"
+    "docs:deploy": "npm run docs:build && rsync -avz --delete docs/.vitepress/dist/ ${DOCS_DEPLOY_HOST:?Set DOCS_DEPLOY_HOST}:~/chris-assistant-docs/"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.114",

--- a/scripts/check-docs-routes.js
+++ b/scripts/check-docs-routes.js
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+const distDir = join(process.cwd(), "docs", ".vitepress", "dist");
+
+const routes = [
+  { path: "getting-started/overview", title: "Overview" },
+  { path: "operating-manual", title: "Operating Manual" },
+  { path: "architecture/providers", title: "Providers" },
+  { path: "tools/memory", title: "Memory" },
+  { path: "cli/reference", title: "CLI Command Reference" },
+];
+
+function stripTags(value) {
+  return value.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+}
+
+function readRoute(routePath) {
+  const filePath = join(distDir, routePath, "index.html");
+  if (!existsSync(filePath)) {
+    throw new Error(`Missing extensionless route artifact: ${routePath}/index.html`);
+  }
+  return readFileSync(filePath, "utf-8");
+}
+
+for (const route of routes) {
+  const html = readRoute(route.path);
+  const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/);
+  const h1 = h1Match ? stripTags(h1Match[1]) : "";
+
+  if (!h1.includes(route.title)) {
+    throw new Error(`Route ${route.path} rendered "${h1 || "(no h1)"}", expected "${route.title}"`);
+  }
+
+  if (route.path !== "index" && h1.includes("Personal AI Assistant")) {
+    throw new Error(`Route ${route.path} appears to contain the home page fallback`);
+  }
+}
+
+console.log(`[docs] Smoke checked ${routes.length} extensionless deep routes`);

--- a/scripts/prepare-docs-routes.js
+++ b/scripts/prepare-docs-routes.js
@@ -1,0 +1,43 @@
+import { copyFileSync, mkdirSync, readdirSync, statSync } from "fs";
+import { basename, dirname, join, relative } from "path";
+
+const distDir = join(process.cwd(), "docs", ".vitepress", "dist");
+
+function walk(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+let created = 0;
+
+for (const filePath of walk(distDir)) {
+  if (!filePath.endsWith(".html")) continue;
+  if (basename(filePath) === "index.html" || basename(filePath) === "404.html") continue;
+
+  const routePath = filePath.slice(0, -".html".length);
+  const aliasPath = join(routePath, "index.html");
+
+  if (filePath === aliasPath) continue;
+  try {
+    if (statSync(routePath).isFile()) continue;
+  } catch {
+    // No exact file at the extensionless route, so create a directory alias.
+  }
+
+  mkdirSync(routePath, { recursive: true });
+  copyFileSync(filePath, aliasPath);
+  created++;
+}
+
+console.log(`[docs] Prepared ${created} extensionless route aliases in ${relative(process.cwd(), distDir)}`);

--- a/src/domain/conversations/archive-service.ts
+++ b/src/domain/conversations/archive-service.ts
@@ -129,7 +129,7 @@ export function startArchiveUploader(): void {
     return;
   }
 
-  console.log("[archive] Starting archive uploader (every 30 minutes)");
+  console.log("[archive] Starting archive uploader (every 5 minutes)");
   uploadArchives().catch((err: any) => {
     console.error("[archive] Unexpected error during initial upload:", err.message);
   });

--- a/src/domain/memory/dream-prompt.ts
+++ b/src/domain/memory/dream-prompt.ts
@@ -6,7 +6,7 @@
 
 export const DREAM_CONSOLIDATION_PROMPT = `IMPORTANT: This is a memory consolidation task. Do NOT use any tools. Do NOT call Bash, Read, Edit, Write, or any other tool. Your ENTIRE response must be a single JSON object inside a markdown code block. No tool calls. No file operations. Just return the JSON.
 
-You are performing a memory consolidation for an AI assistant called Claw. You are "dreaming" — reviewing recent conversations and updating memory files to keep them accurate and useful.
+You are performing a memory consolidation for Chris Assistant. You are "dreaming" — reviewing recent conversations and updating memory files to keep them accurate and useful.
 
 All the information you need is provided below in this message. Do not attempt to read files or run commands.
 


### PR DESCRIPTION
## Summary
- add a docs post-build step that creates extensionless deep-route aliases (`page/index.html`) for the static docs host
- add a docs route smoke test and run `npm run docs:build` in CI
- add the Chris Assistant operating manual covering memory, recall, correction, inspection, and provider mode choice
- refresh stale docs/runtime wording around provider sessions, direct memory writes, archive upload cadence, repository links, and Telegram HTML rendering
- align two runtime strings with the recovered docs story: archive upload log cadence and DreamTask assistant name

## User-facing behavior change
Deep docs links such as `/architecture/providers` now build as real route artifacts instead of relying on the host fallback. The docs also include a single operating manual that explains what Chris Assistant remembers, how recall works, how to inspect/correct memory, and when to use Claude/OpenAI Responses versus Codex Agent.

## Tests run
- npm run typecheck
- npm test
- npm run docs:build
- local static smoke: `python3 -m http.server 4173 --directory docs/.vitepress/dist`, then requested `/architecture/providers` and `/operating-manual` without `.html`

## Manual acceptance checklist
- [x] Built deep pages contain their own page titles via `scripts/check-docs-routes.js`
- [x] Extensionless route artifacts are generated under `docs/.vitepress/dist/<route>/index.html`
- [x] README, local docs, CLI-facing docs, and provider docs describe shipped runtime behavior
- [x] Planned/provider-limited behavior is separated from shipped behavior in the operating manual and provider docs
- [x] Live deploy command now uses the same docs build and smoke test before rsync

## Deployment note
`DOCS_DEPLOY_HOST` is not set in this shell, so I verified the generated artifact locally but did not deploy the live site from here. After merge, `npm run docs:deploy` will publish the route aliases when run in the configured deploy environment.

## Links
- Part of #115
- Addresses #114
