### PR TITLE
feat: add proactive notice loop core

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,10 @@ GITHUB_MEMORY_REPO=your-username/chris-assistant-memory
 # Optional: GitHub webhook for PR merge notifications to Discord
 # GITHUB_WEBHOOK_SECRET=your_webhook_secret_here
 # WEBHOOK_PORT=3001
+
+# Optional: proactive journal-gap notices (disabled by default)
+# NOTICE_LOOP_ENABLED=true
+# NOTICE_LOOP_INTERVAL_MINUTES=60
+# NOTICE_QUIET_START_HOUR=22
+# NOTICE_QUIET_END_HOUR=8
+# NOTICE_JOURNAL_GAP_DAYS=2

--- a/README.md
+++ b/README.md
@@ -267,6 +267,11 @@ Maintenance:
 | `DASHBOARD_TOKEN` | No | Auth token for remote dashboard access |
 | `WEBHOOK_PORT` | No | GitHub webhook server port (default: 3001) |
 | `SYMPHONY_STATUS_URL` | No | Symphony status page URL (default: `http://127.0.0.1:3010`) |
+| `NOTICE_LOOP_ENABLED` | No | Enable proactive notices (default: `false`) |
+| `NOTICE_LOOP_INTERVAL_MINUTES` | No | Notice scan interval (default: `60`) |
+| `NOTICE_QUIET_START_HOUR` | No | Local quiet-hours start, 0–23 (default: `22`) |
+| `NOTICE_QUIET_END_HOUR` | No | Local quiet-hours end, 0–23 (default: `8`) |
+| `NOTICE_JOURNAL_GAP_DAYS` | No | Days without journal activity before a nudge (default: `2`) |
 
 Config is validated through a typed zod schema in `src/infra/config/` (`src/config.ts` is a compatibility facade). Run `chris setup` for guided configuration.
 

--- a/docs/cli/environment.md
+++ b/docs/cli/environment.md
@@ -31,6 +31,11 @@ description: Environment variables, file paths, and configuration
 | `OCTOPUS_API_KEY` | No | Octopus Energy API key — required for the `octopus_energy` tool |
 | `OCTOPUS_ACCOUNT_NUMBER` | No | Octopus Energy account number (e.g. `A-XXXXXXXX`) |
 | `SYMPHONY_STATUS_URL` | No | Symphony sidecar status endpoint. Default: `http://127.0.0.1:3010` |
+| `NOTICE_LOOP_ENABLED` | No | Enables proactive notices. Default: `false` |
+| `NOTICE_LOOP_INTERVAL_MINUTES` | No | Notice scan interval. Default: `60` |
+| `NOTICE_QUIET_START_HOUR` | No | Local quiet-hours start, 0–23. Default: `22` |
+| `NOTICE_QUIET_END_HOUR` | No | Local quiet-hours end, 0–23. Default: `8` |
+| `NOTICE_JOURNAL_GAP_DAYS` | No | Days without journal activity before a nudge. Default: `2` |
 
 OpenAI authenticates via browser OAuth + PKCE (`chris openai login`). MiniMax uses OAuth device flow (`chris minimax login`). Tokens stored in `~/.chris-assistant/`.
 

--- a/src/app/service-definitions.ts
+++ b/src/app/service-definitions.ts
@@ -13,6 +13,7 @@ import { startDashboard, stopDashboard } from "../dashboard.js";
 import { startWebhook, stopWebhook } from "../webhook.js";
 import { ensureLocalMemoryDir } from "../domain/memory/recall.js";
 import { setTelegramCommandMenu } from "../channels/telegram/index.js";
+import { startNoticeLoop, stopNoticeLoop } from "../domain/notice/runtime.js";
 
 export function createPreTelegramRegistry(): ServiceRegistry {
   return new ServiceRegistry([
@@ -41,6 +42,7 @@ export function createPostTelegramRegistry(): ServiceRegistry {
     createService("journal-uploader", () => startJournalUploader(), () => stopJournalUploader()),
     createService("memory-consolidation", () => startMemoryConsolidation(), () => stopMemoryConsolidation()),
     createService("heartbeat", () => startHeartbeat(), () => stopHeartbeat()),
+    createService("notice-loop", () => startNoticeLoop(), () => stopNoticeLoop()),
     createService("dashboard", () => startDashboard(), () => stopDashboard()),
     createService("discord", () => startDiscord(), () => stopDiscord()),
     createService("webhook", () => startWebhook(), () => stopWebhook()),

--- a/src/domain/notice/journal-gap-scanner.ts
+++ b/src/domain/notice/journal-gap-scanner.ts
@@ -1,0 +1,46 @@
+import type { NoticeCandidate, NoticeScanner } from "./types.js";
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function localDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function dayNumber(dateKey: string): number {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  return Math.floor(Date.UTC(year, month - 1, day) / 86_400_000);
+}
+
+export class JournalGapScanner implements NoticeScanner {
+  readonly name = "journal-gap";
+
+  constructor(
+    private readonly gapDays: number,
+    private readonly listDates: () => string[],
+  ) {}
+
+  scan(now: Date): NoticeCandidate[] {
+    const today = localDateKey(now);
+    const dates = this.listDates().filter((date) => DATE_PATTERN.test(date)).sort();
+    const latest = dates.at(-1);
+    const gap = latest ? Math.max(0, dayNumber(today) - dayNumber(latest)) : null;
+
+    if (gap !== null && gap < this.gapDays) return [];
+
+    const summary = gap === null
+      ? "Your journal has no entries yet. Worth capturing what changed today?"
+      : `Your journal has been quiet for ${gap} days. Worth capturing what changed?`;
+    const evidence = latest ? `Most recent journal entry: ${latest}.` : "No dated journal files found.";
+
+    return [{
+      key: `journal-gap:${today}`,
+      priority: 50,
+      summary,
+      evidence,
+      suppressUntil: now.getTime() + 24 * 60 * 60 * 1000,
+    }];
+  }
+}

--- a/src/domain/notice/notice-service.ts
+++ b/src/domain/notice/notice-service.ts
@@ -1,0 +1,113 @@
+import type { JsonStore } from "../../infra/storage/json-store.js";
+import type {
+  NoticeCandidate,
+  NoticeDelivery,
+  NoticeLoopOptions,
+  NoticeScanner,
+  NoticeState,
+} from "./types.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function localDateKey(date: Date): string {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function isQuietHour(hour: number, start: number, end: number): boolean {
+  if (start === end) return false;
+  if (start < end) return hour >= start && hour < end;
+  return hour >= start || hour < end;
+}
+
+function formatNotice(candidate: NoticeCandidate): string {
+  return candidate.evidence
+    ? `${candidate.summary}\n\n${candidate.evidence}`
+    : candidate.summary;
+}
+
+export class NoticeService {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(
+    private readonly options: NoticeLoopOptions,
+    private readonly scanners: NoticeScanner[],
+    private readonly delivery: NoticeDelivery,
+    private readonly stateStore: JsonStore<NoticeState>,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  start(): void {
+    if (!this.options.enabled) {
+      console.log("[notice] Notice loop disabled");
+      return;
+    }
+    if (this.timer !== null) return;
+
+    console.log("[notice] Starting notice loop (every %d minutes)", this.options.intervalMs / 60_000);
+    void this.runOnce();
+    this.timer = setInterval(() => { void this.runOnce(); }, this.options.intervalMs);
+    this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+      console.log("[notice] Notice loop stopped");
+    }
+  }
+
+  async runOnce(): Promise<NoticeCandidate | null> {
+    if (!this.options.enabled || this.running) return null;
+    this.running = true;
+
+    try {
+      const now = this.now();
+      if (isQuietHour(now.getHours(), this.options.quietStartHour, this.options.quietEndHour)) {
+        return null;
+      }
+
+      const nowMs = now.getTime();
+      const state = this.stateStore.read();
+      const recentDeliveries = state.deliveries.filter((entry) => nowMs - entry.sentAt < 7 * DAY_MS);
+      const lastDelivery = recentDeliveries.at(-1);
+      if (lastDelivery && nowMs - lastDelivery.sentAt < this.options.minGapMs) return null;
+
+      const today = localDateKey(now);
+      const sentToday = recentDeliveries.filter((entry) => localDateKey(new Date(entry.sentAt)) === today);
+      if (sentToday.length >= this.options.dailyLimit) return null;
+
+      const results = await Promise.allSettled(this.scanners.map((scanner) => scanner.scan(now)));
+      const candidates: NoticeCandidate[] = [];
+      results.forEach((result, index) => {
+        if (result.status === "fulfilled") {
+          candidates.push(...result.value);
+        } else {
+          console.error("[notice] Scanner %s failed: %s", this.scanners[index]?.name, result.reason?.message ?? result.reason);
+        }
+      });
+
+      const selected = candidates
+        .filter((candidate) => (state.suppressedUntil[candidate.key] ?? 0) <= nowMs)
+        .sort((a, b) => b.priority - a.priority || a.key.localeCompare(b.key))[0];
+      if (!selected) return null;
+
+      await this.delivery.send(formatNotice(selected));
+      this.stateStore.write({
+        deliveries: [...recentDeliveries, { key: selected.key, sentAt: nowMs }],
+        suppressedUntil: {
+          ...state.suppressedUntil,
+          [selected.key]: selected.suppressUntil ?? nowMs + DAY_MS,
+        },
+      });
+      return selected;
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/src/domain/notice/runtime.ts
+++ b/src/domain/notice/runtime.ts
@@ -1,0 +1,25 @@
+import { config } from "../../config.js";
+import { bot } from "../../channels/telegram/bot.js";
+import { listLocalJournalDates } from "../memory/journal-service.js";
+import { JournalGapScanner } from "./journal-gap-scanner.js";
+import { NoticeService } from "./notice-service.js";
+import { createNoticeStateStore } from "./state.js";
+
+const noticeService = new NoticeService(
+  config.notice,
+  [new JournalGapScanner(config.notice.journalGapDays, listLocalJournalDates)],
+  {
+    async send(text: string): Promise<void> {
+      await bot.api.sendMessage(config.telegram.allowedUserId, text);
+    },
+  },
+  createNoticeStateStore(),
+);
+
+export function startNoticeLoop(): void {
+  noticeService.start();
+}
+
+export function stopNoticeLoop(): void {
+  noticeService.stop();
+}

--- a/src/domain/notice/state.ts
+++ b/src/domain/notice/state.ts
@@ -1,0 +1,14 @@
+import { JsonStore } from "../../infra/storage/json-store.js";
+import { appDataPath } from "../../infra/storage/paths.js";
+import type { NoticeState } from "./types.js";
+
+const EMPTY_NOTICE_STATE: NoticeState = {
+  deliveries: [],
+  suppressedUntil: {},
+};
+
+export function createNoticeStateStore(
+  filePath = appDataPath("notice-state.json"),
+): JsonStore<NoticeState> {
+  return new JsonStore<NoticeState>(filePath, EMPTY_NOTICE_STATE);
+}

--- a/src/domain/notice/types.ts
+++ b/src/domain/notice/types.ts
@@ -1,0 +1,35 @@
+export interface NoticeCandidate {
+  key: string;
+  priority: number;
+  summary: string;
+  evidence?: string;
+  suppressUntil?: number;
+}
+
+export interface NoticeScanner {
+  name: string;
+  scan(now: Date): Promise<NoticeCandidate[]> | NoticeCandidate[];
+}
+
+export interface NoticeDelivery {
+  send(text: string): Promise<void>;
+}
+
+export interface NoticeLoopOptions {
+  enabled: boolean;
+  intervalMs: number;
+  quietStartHour: number;
+  quietEndHour: number;
+  minGapMs: number;
+  dailyLimit: number;
+}
+
+export interface NoticeDeliveryRecord {
+  key: string;
+  sentAt: number;
+}
+
+export interface NoticeState {
+  deliveries: NoticeDeliveryRecord[];
+  suppressedUntil: Record<string, number>;
+}

--- a/src/infra/config/load-config.ts
+++ b/src/infra/config/load-config.ts
@@ -76,6 +76,15 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): { config: AppC
       symphony: {
         statusUrl: values.SYMPHONY_STATUS_URL || "http://127.0.0.1:3010",
       },
+      notice: {
+        enabled: values.NOTICE_LOOP_ENABLED ?? false,
+        intervalMs: (values.NOTICE_LOOP_INTERVAL_MINUTES ?? 60) * 60_000,
+        quietStartHour: values.NOTICE_QUIET_START_HOUR ?? 22,
+        quietEndHour: values.NOTICE_QUIET_END_HOUR ?? 8,
+        minGapMs: 4 * 60 * 60 * 1000,
+        dailyLimit: 2,
+        journalGapDays: values.NOTICE_JOURNAL_GAP_DAYS ?? 2,
+      },
       octopus: {
         apiKey: normalizeOptional(values.OCTOPUS_API_KEY),
         accountNumber: normalizeOptional(values.OCTOPUS_ACCOUNT_NUMBER),

--- a/src/infra/config/schema.ts
+++ b/src/infra/config/schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 const envString = z.string().min(1);
 const optionalString = z.string().min(1).nullable();
+const optionalBooleanString = z.enum(["true", "false"]).transform((value) => value === "true").optional();
 
 export const envSchema = z.object({
   AI_MODEL: z.string().optional(),
@@ -33,6 +34,11 @@ export const envSchema = z.object({
   OCTOPUS_API_KEY: z.string().optional(),
   OCTOPUS_ACCOUNT_NUMBER: z.string().optional(),
   VOYAGE_API_KEY: z.string().optional(),
+  NOTICE_LOOP_ENABLED: optionalBooleanString,
+  NOTICE_LOOP_INTERVAL_MINUTES: z.coerce.number().int().positive().optional(),
+  NOTICE_QUIET_START_HOUR: z.coerce.number().int().min(0).max(23).optional(),
+  NOTICE_QUIET_END_HOUR: z.coerce.number().int().min(0).max(23).optional(),
+  NOTICE_JOURNAL_GAP_DAYS: z.coerce.number().int().positive().optional(),
 });
 
 export function normalizeOptional(value?: string): string | null {

--- a/src/infra/config/types.ts
+++ b/src/infra/config/types.ts
@@ -32,6 +32,15 @@ export interface AppConfig {
   symphony: {
     statusUrl: string;
   };
+  notice: {
+    enabled: boolean;
+    intervalMs: number;
+    quietStartHour: number;
+    quietEndHour: number;
+    minGapMs: number;
+    dailyLimit: number;
+    journalGapDays: number;
+  };
   octopus: {
     apiKey: string | null;
     accountNumber: string | null;

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -20,7 +20,34 @@ describe("loadConfig", () => {
     expect(config.telegram.allowedUserId).toBe(12345);
     expect(config.discord.botToken).toBeNull();
     expect(config.dashboard.token).toBeNull();
+    expect(config.notice).toMatchObject({
+      enabled: false,
+      intervalMs: 60 * 60 * 1000,
+      quietStartHour: 22,
+      quietEndHour: 8,
+      dailyLimit: 2,
+      journalGapDays: 2,
+    });
     expect(repo).toEqual({ owner: "owner", name: "repo" });
+  });
+
+  it("loads notice-loop settings", () => {
+    const { config } = loadConfig({
+      ...baseEnv,
+      NOTICE_LOOP_ENABLED: "true",
+      NOTICE_LOOP_INTERVAL_MINUTES: "30",
+      NOTICE_QUIET_START_HOUR: "21",
+      NOTICE_QUIET_END_HOUR: "7",
+      NOTICE_JOURNAL_GAP_DAYS: "3",
+    });
+
+    expect(config.notice).toMatchObject({
+      enabled: true,
+      intervalMs: 30 * 60 * 1000,
+      quietStartHour: 21,
+      quietEndHour: 7,
+      journalGapDays: 3,
+    });
   });
 
   it("prefers AI_MODEL over CLAUDE_MODEL and parses optional fields", () => {

--- a/tests/notice-service.test.ts
+++ b/tests/notice-service.test.ts
@@ -1,0 +1,151 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { JournalGapScanner } from "../src/domain/notice/journal-gap-scanner.js";
+import { NoticeService } from "../src/domain/notice/notice-service.js";
+import { createNoticeStateStore } from "../src/domain/notice/state.js";
+import type { NoticeCandidate, NoticeScanner } from "../src/domain/notice/types.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function stateStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "notice-state-"));
+  tempDirs.push(dir);
+  return createNoticeStateStore(path.join(dir, "state.json"));
+}
+
+function candidate(key: string, priority = 50): NoticeCandidate {
+  return { key, priority, summary: `Summary ${key}`, evidence: `Evidence ${key}` };
+}
+
+function scanner(...candidates: NoticeCandidate[]): NoticeScanner {
+  return { name: "test", scan: () => candidates };
+}
+
+function options(overrides: Partial<ConstructorParameters<typeof NoticeService>[0]> = {}) {
+  return {
+    enabled: true,
+    intervalMs: 60 * 60 * 1000,
+    quietStartHour: 22,
+    quietEndHour: 8,
+    minGapMs: 4 * 60 * 60 * 1000,
+    dailyLimit: 2,
+    ...overrides,
+  };
+}
+
+describe("NoticeService", () => {
+  it("delivers highest-priority candidate and persists evidence", async () => {
+    const sent: string[] = [];
+    const store = stateStore();
+    const now = new Date(2026, 6, 6, 12, 0);
+    const service = new NoticeService(
+      options(),
+      [scanner(candidate("low", 10), candidate("high", 90))],
+      { async send(text) { sent.push(text); } },
+      store,
+      () => now,
+    );
+
+    await expect(service.runOnce()).resolves.toMatchObject({ key: "high" });
+    expect(sent).toEqual(["Summary high\n\nEvidence high"]);
+    expect(store.read().deliveries).toEqual([{ key: "high", sentAt: now.getTime() }]);
+  });
+
+  it("does not scan or deliver during overnight quiet hours", async () => {
+    const scan = vi.fn(() => [candidate("quiet")]);
+    const send = vi.fn(async () => {});
+    const service = new NoticeService(
+      options(),
+      [{ name: "test", scan }],
+      { send },
+      stateStore(),
+      () => new Date(2026, 6, 6, 23, 0),
+    );
+
+    await expect(service.runOnce()).resolves.toBeNull();
+    expect(scan).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("enforces minimum gap and daily cap from persisted state", async () => {
+    const store = stateStore();
+    const first = new Date(2026, 6, 6, 9, 0);
+    let now = first;
+    const send = vi.fn(async () => {});
+    const service = new NoticeService(
+      options(),
+      [{ name: "test", scan: (date) => [candidate(`at-${date.getHours()}`)] }],
+      { send },
+      store,
+      () => now,
+    );
+
+    await service.runOnce();
+    now = new Date(2026, 6, 6, 12, 59);
+    await expect(service.runOnce()).resolves.toBeNull();
+    now = new Date(2026, 6, 6, 13, 0);
+    await service.runOnce();
+    now = new Date(2026, 6, 6, 18, 0);
+    await expect(service.runOnce()).resolves.toBeNull();
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("isolates scanner failures", async () => {
+    const send = vi.fn(async () => {});
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const service = new NoticeService(
+      options(),
+      [
+        { name: "broken", scan: async () => { throw new Error("boom"); } },
+        scanner(candidate("healthy")),
+      ],
+      { send },
+      stateStore(),
+      () => new Date(2026, 6, 6, 12, 0),
+    );
+
+    await expect(service.runOnce()).resolves.toMatchObject({ key: "healthy" });
+    expect(send).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+
+  it("stays inert when disabled", async () => {
+    vi.useFakeTimers();
+    const scan = vi.fn(() => [candidate("disabled")]);
+    const service = new NoticeService(
+      options({ enabled: false }),
+      [{ name: "test", scan }],
+      { send: vi.fn(async () => {}) },
+      stateStore(),
+    );
+
+    service.start();
+    await vi.runOnlyPendingTimersAsync();
+    expect(scan).not.toHaveBeenCalled();
+  });
+});
+
+describe("JournalGapScanner", () => {
+  it("returns nothing when journal is recent", () => {
+    const scanner = new JournalGapScanner(2, () => ["2026-07-05"]);
+    expect(scanner.scan(new Date(2026, 6, 6, 12, 0))).toEqual([]);
+  });
+
+  it("reports stale journal with evidence", () => {
+    const scanner = new JournalGapScanner(2, () => ["junk", "2026-07-02"]);
+    expect(scanner.scan(new Date(2026, 6, 6, 12, 0))).toEqual([
+      expect.objectContaining({
+        key: "journal-gap:2026-07-06",
+        summary: expect.stringContaining("4 days"),
+        evidence: "Most recent journal entry: 2026-07-02.",
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds first vertical slice of #80:

- typed notice scanner/delivery contracts and deterministic ranking
- hourly `AppService` lifecycle integration
- persisted delivery and suppression state
- local quiet hours, four-hour minimum gap, and two-notices-per-day cap
- journal-gap scanner
- fresh Telegram delivery to configured owner
- disabled-by-default configuration and operator docs

## User-facing behavior

When `NOTICE_LOOP_ENABLED=true`, Chris Assistant scans on startup and at configured intervals. Outside quiet hours, it can send a journal-gap nudge. Delivery state survives restarts, preventing repeated nudges. Default remains disabled.

## Tests run

- `npm ci`
- `npm run typecheck`
- `npm test` — 248/248 passed
- `npm run docs:build`
- controlled live Telegram acceptance harness

## Manual acceptance checklist

- [x] Start with `NOTICE_LOOP_ENABLED=false`; confirmed disabled log and no scan/message
- [x] Start with stale/no journal and `NOTICE_LOOP_ENABLED=true` outside quiet hours; confirmed one fresh Telegram nudge
- [x] Restart within four hours; confirmed persisted state suppresses duplicate nudge
- [x] Confirmed no nudge during configured quiet hours (23:00 local)

## Follow-up

Calendar conflict scanner remains a second PR because typed EventKit access must be extracted from the current tool implementation. Keep #80 open until that slice lands.

Refs #80.