### PR TITLE
feat: add calendar conflict notices

### DIFF
--- a/src/domain/notice/calendar-conflict-scanner.ts
+++ b/src/domain/notice/calendar-conflict-scanner.ts
@@ -1,0 +1,65 @@
+import type { CalendarEvent } from "../../tools/macos/calendar-client.js";
+import type { NoticeCandidate, NoticeScanner } from "./types.js";
+
+const BACK_TO_BACK_WINDOW_MS = 15 * 60 * 1000;
+
+function formatTime(date: Date): string {
+  return date.toLocaleString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function candidateKey(prefix: string, first: CalendarEvent, second: CalendarEvent): string {
+  return `${prefix}:${[first.uid, second.uid].sort().join(":")}:${first.start}:${second.start}`;
+}
+
+export class CalendarConflictScanner implements NoticeScanner {
+  readonly name = "calendar-conflict";
+
+  constructor(private readonly getEvents: (now: Date) => Promise<CalendarEvent[]>) {}
+
+  async scan(now: Date): Promise<NoticeCandidate[]> {
+    const events = (await this.getEvents(now))
+      .filter((event) => !event.allDay && new Date(event.end).getTime() > now.getTime())
+      .sort((left, right) => new Date(left.start).getTime() - new Date(right.start).getTime());
+    const candidates: NoticeCandidate[] = [];
+
+    for (let index = 0; index < events.length - 1; index += 1) {
+      const first = events[index]!;
+      const firstEnd = new Date(first.end).getTime();
+      for (let following = index + 1; following < events.length; following += 1) {
+        const second = events[following]!;
+        const secondStart = new Date(second.start).getTime();
+        if (secondStart >= firstEnd) break;
+        candidates.push({
+          key: candidateKey("calendar-overlap", first, second),
+          priority: 90,
+          summary: `Calendar conflict: “${first.title}” overlaps “${second.title}”.`,
+          evidence: `${formatTime(new Date(first.start))}–${formatTime(new Date(first.end))} (${first.calendar}) and ${formatTime(new Date(second.start))}–${formatTime(new Date(second.end))} (${second.calendar}).`,
+          suppressUntil: now.getTime() + 24 * 60 * 60 * 1000,
+        });
+      }
+
+      const second = events[index + 1]!;
+      const gap = new Date(second.start).getTime() - firstEnd;
+      if (gap >= 0 && gap <= BACK_TO_BACK_WINDOW_MS) {
+        const gapMinutes = Math.round(gap / 60_000);
+        candidates.push({
+          key: candidateKey("calendar-back-to-back", first, second),
+          priority: 70,
+          summary: gapMinutes === 0
+            ? `Back-to-back meetings: “${first.title}” then “${second.title}”.`
+            : `Tight calendar gap: ${gapMinutes} minutes between “${first.title}” and “${second.title}”.`,
+          evidence: `${formatTime(new Date(first.end))} to ${formatTime(new Date(second.start))}.`,
+          suppressUntil: now.getTime() + 24 * 60 * 60 * 1000,
+        });
+      }
+    }
+
+    return candidates;
+  }
+}

--- a/src/domain/notice/runtime.ts
+++ b/src/domain/notice/runtime.ts
@@ -1,13 +1,19 @@
 import { config } from "../../config.js";
 import { bot } from "../../channels/telegram/bot.js";
 import { listLocalJournalDates } from "../memory/journal-service.js";
+import { listUpcomingCalendarEvents } from "../../tools/macos/calendar-client.js";
+import { IS_DARWIN } from "../../tools/macos/shared.js";
+import { CalendarConflictScanner } from "./calendar-conflict-scanner.js";
 import { JournalGapScanner } from "./journal-gap-scanner.js";
 import { NoticeService } from "./notice-service.js";
 import { createNoticeStateStore } from "./state.js";
 
 const noticeService = new NoticeService(
   config.notice,
-  [new JournalGapScanner(config.notice.journalGapDays, listLocalJournalDates)],
+  [
+    new JournalGapScanner(config.notice.journalGapDays, listLocalJournalDates),
+    ...(IS_DARWIN ? [new CalendarConflictScanner(listUpcomingCalendarEvents)] : []),
+  ],
   {
     async send(text: string): Promise<void> {
       await bot.api.sendMessage(config.telegram.allowedUserId, text);

--- a/src/tools/macos-calendar.ts
+++ b/src/tools/macos-calendar.ts
@@ -1,46 +1,15 @@
 import { z } from "zod";
 import { registerTool } from "./registry.js";
-import {
-  CALENDAR_APP,
-  CALENDAR_TIMEOUT,
-  CALENDAR_SETUP_CMD,
-  DEFAULT_CALENDAR,
-  IS_DARWIN,
-  runSwiftHelper,
-} from "./macos/shared.js";
+import { DEFAULT_CALENDAR, IS_DARWIN } from "./macos/shared.js";
+import { formatCalendarEvents, runCalendarCommand } from "./macos/calendar-client.js";
 
 // ---------------------------------------------------------------------------
 // Calendar: Swift EventKit binary (fast, <1s)
 // ---------------------------------------------------------------------------
 
-async function runCalendar(args: string[]): Promise<string> {
-  return runSwiftHelper(CALENDAR_APP, args, {
-    timeoutMs: CALENDAR_TIMEOUT,
-    filePrefix: "chris-cal",
-    notFoundMessage:
-      `Error: Calendar helper not found at ${CALENDAR_APP}. ` +
-      `Install it with: ${CALENDAR_SETUP_CMD}`,
-  });
-}
-
 function formatEvents(json: string): string {
   try {
-    const events = JSON.parse(json);
-    if (!Array.isArray(events) || events.length === 0) return "No events found.";
-    return events.map((e: any) => {
-      const start = new Date(e.start);
-      const end = new Date(e.end);
-      const timeFmt = (d: Date) =>
-        d.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
-      const dateFmt = (d: Date) =>
-        d.toLocaleDateString("en-GB", { weekday: "short", day: "numeric", month: "short" });
-
-      let line = e.allDay
-        ? `${dateFmt(start)} (all day) — ${e.title}`
-        : `${dateFmt(start)} ${timeFmt(start)}–${timeFmt(end)} — ${e.title}`;
-      if (e.location) line += ` 📍 ${e.location}`;
-      return line;
-    }).join("\n");
+    return formatCalendarEvents(JSON.parse(json));
   } catch {
     return json; // Return raw if parse fails
   }
@@ -136,7 +105,7 @@ if (!IS_DARWIN) {
       try {
         switch (action) {
           case "list_calendars":
-            return await runCalendar(["list-calendars"]);
+            return await runCalendarCommand(["list-calendars"]);
 
           case "get_events": {
             if (!start_date) return "Error: start_date is required for get_events";
@@ -148,7 +117,7 @@ if (!IS_DARWIN) {
               d.setDate(d.getDate() + 1);
               end = d.toISOString().split("T")[0];
             }
-            const raw = await runCalendar(["get-events", cal, start_date, end]);
+            const raw = await runCalendarCommand(["get-events", cal, start_date, end]);
             // Try to format nicely, fall back to raw
             if (raw.startsWith("Error:")) return raw;
             try {
@@ -171,7 +140,7 @@ if (!IS_DARWIN) {
             if (location) cmdArgs.push("--location", location);
             if (notes) cmdArgs.push("--notes", notes);
             if (all_day) cmdArgs.push("--allday");
-            return await runCalendar(cmdArgs);
+            return await runCalendarCommand(cmdArgs);
           }
 
           case "update_event": {
@@ -192,7 +161,7 @@ if (!IS_DARWIN) {
             }
             if (all_day === true) cmdArgs.push("--allday");
             if (all_day === false) cmdArgs.push("--no-allday");
-            const updateRaw = await runCalendar(cmdArgs);
+            const updateRaw = await runCalendarCommand(cmdArgs);
             if (updateRaw.startsWith("Error:")) return updateRaw;
             // Format the returned updated event
             try {
@@ -209,7 +178,7 @@ if (!IS_DARWIN) {
             if (start_date) cmdArgs.push("--from", start_date);
             if (end_date) cmdArgs.push("--to", end_date);
             if (max_results) cmdArgs.push("--max", String(max_results));
-            const searchRaw = await runCalendar(cmdArgs);
+            const searchRaw = await runCalendarCommand(cmdArgs);
             if (searchRaw.startsWith("Error:")) return searchRaw;
             try {
               const parsed = JSON.parse(searchRaw);
@@ -230,7 +199,7 @@ if (!IS_DARWIN) {
               if (!start_date) return "Error: start_date is required when deleting by title (scopes to a single day)";
               cmdArgs.push(title!, "--date", start_date);
             }
-            return await runCalendar(cmdArgs);
+            return await runCalendarCommand(cmdArgs);
           }
 
           default:

--- a/src/tools/macos/calendar-client.ts
+++ b/src/tools/macos/calendar-client.ts
@@ -1,0 +1,111 @@
+import {
+  CALENDAR_APP,
+  CALENDAR_SETUP_CMD,
+  CALENDAR_TIMEOUT,
+  runSwiftHelper,
+} from "./shared.js";
+
+export interface CalendarEvent {
+  title: string;
+  start: string;
+  end: string;
+  allDay: boolean;
+  location: string | null;
+  notes: string | null;
+  calendar: string;
+  uid: string;
+}
+
+export type CalendarCommand = (args: string[]) => Promise<string>;
+
+export async function runCalendarCommand(args: string[]): Promise<string> {
+  return runSwiftHelper(CALENDAR_APP, args, {
+    timeoutMs: CALENDAR_TIMEOUT,
+    filePrefix: "chris-cal",
+    notFoundMessage:
+      `Error: Calendar helper not found at ${CALENDAR_APP}. ` +
+      `Install it with: ${CALENDAR_SETUP_CMD}`,
+  });
+}
+
+export function parseCalendarEvents(raw: string): CalendarEvent[] {
+  if (raw.startsWith("Error:")) throw new Error(raw);
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error("Calendar helper returned a non-array event payload");
+
+  return parsed.map((event): CalendarEvent => {
+    if (!event || typeof event !== "object") throw new Error("Calendar helper returned an invalid event");
+    const value = event as Record<string, unknown>;
+    if (typeof value.title !== "string" || typeof value.start !== "string" || typeof value.end !== "string"
+      || typeof value.allDay !== "boolean" || typeof value.calendar !== "string" || typeof value.uid !== "string") {
+      throw new Error("Calendar helper returned an incomplete event");
+    }
+    return {
+      title: value.title,
+      start: value.start,
+      end: value.end,
+      allDay: value.allDay,
+      location: typeof value.location === "string" ? value.location : null,
+      notes: typeof value.notes === "string" ? value.notes : null,
+      calendar: value.calendar,
+      uid: value.uid,
+    };
+  });
+}
+
+export async function listCalendarNames(command: CalendarCommand = runCalendarCommand): Promise<string[]> {
+  const raw = await command(["list-calendars"]);
+  if (raw.startsWith("Error:")) throw new Error(raw);
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed) || parsed.some((name) => typeof name !== "string")) {
+    throw new Error("Calendar helper returned an invalid calendar list");
+  }
+  return parsed;
+}
+
+export async function listCalendarEvents(
+  start: string,
+  end: string,
+  command: CalendarCommand = runCalendarCommand,
+): Promise<CalendarEvent[]> {
+  const calendars = await listCalendarNames(command);
+  const results = await Promise.all(calendars.map(async (calendar) => {
+    const raw = await command(["get-events", calendar, start, end]);
+    return parseCalendarEvents(raw);
+  }));
+  return results.flat();
+}
+
+function localDateKey(date: Date): string {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+export async function listUpcomingCalendarEvents(
+  now = new Date(),
+  command: CalendarCommand = runCalendarCommand,
+): Promise<CalendarEvent[]> {
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 2);
+  return listCalendarEvents(localDateKey(start), localDateKey(end), command);
+}
+
+export function formatCalendarEvents(events: CalendarEvent[]): string {
+  if (events.length === 0) return "No events found.";
+  return events.map((event) => {
+    const start = new Date(event.start);
+    const end = new Date(event.end);
+    const timeFmt = (date: Date) => date.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
+    const dateFmt = (date: Date) => date.toLocaleDateString("en-GB", { weekday: "short", day: "numeric", month: "short" });
+    let line = event.allDay
+      ? `${dateFmt(start)} (all day) — ${event.title}`
+      : `${dateFmt(start)} ${timeFmt(start)}–${timeFmt(end)} — ${event.title}`;
+    if (event.location) line += ` 📍 ${event.location}`;
+    return line;
+  }).join("\n");
+}

--- a/tests/calendar-client.test.ts
+++ b/tests/calendar-client.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  listCalendarEvents,
+  listUpcomingCalendarEvents,
+  parseCalendarEvents,
+  type CalendarCommand,
+} from "../src/tools/macos/calendar-client.js";
+
+const event = {
+  title: "Planning",
+  start: "2026-07-09T10:00:00Z",
+  end: "2026-07-09T11:00:00Z",
+  allDay: false,
+  location: null,
+  notes: null,
+  calendar: "Work",
+  uid: "event-1",
+};
+
+describe("calendar client", () => {
+  it("validates EventKit event payloads", () => {
+    expect(parseCalendarEvents(JSON.stringify([event]))).toEqual([event]);
+    expect(() => parseCalendarEvents("Error: denied")).toThrow("denied");
+    expect(() => parseCalendarEvents(JSON.stringify([{ title: "missing fields" }]))).toThrow("incomplete");
+  });
+
+  it("loads events from every calendar", async () => {
+    const calls: string[][] = [];
+    const command: CalendarCommand = async (args) => {
+      calls.push(args);
+      if (args[0] === "list-calendars") return JSON.stringify(["Work", "Personal"]);
+      return JSON.stringify([{ ...event, calendar: args[1], uid: `${args[1]}-1` }]);
+    };
+
+    await expect(listCalendarEvents("2026-07-09", "2026-07-11", command)).resolves.toEqual([
+      { ...event, calendar: "Work", uid: "Work-1" },
+      { ...event, calendar: "Personal", uid: "Personal-1" },
+    ]);
+    expect(calls).toEqual([
+      ["list-calendars"],
+      ["get-events", "Work", "2026-07-09", "2026-07-11"],
+      ["get-events", "Personal", "2026-07-09", "2026-07-11"],
+    ]);
+  });
+
+  it("queries today and tomorrow for proactive scans", async () => {
+    const calls: string[][] = [];
+    const command: CalendarCommand = async (args) => {
+      calls.push(args);
+      return args[0] === "list-calendars" ? JSON.stringify(["Work"]) : JSON.stringify([]);
+    };
+
+    await listUpcomingCalendarEvents(new Date(2026, 6, 9, 12, 0), command);
+    expect(calls).toEqual([
+      ["list-calendars"],
+      ["get-events", "Work", "2026-07-09", "2026-07-11"],
+    ]);
+  });
+});

--- a/tests/calendar-conflict-scanner.test.ts
+++ b/tests/calendar-conflict-scanner.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { CalendarConflictScanner } from "../src/domain/notice/calendar-conflict-scanner.js";
+import type { CalendarEvent } from "../src/tools/macos/calendar-client.js";
+
+const now = new Date("2026-07-09T09:00:00.000Z");
+
+function event(
+  uid: string,
+  title: string,
+  start: string,
+  end: string,
+  overrides: Partial<CalendarEvent> = {},
+): CalendarEvent {
+  return {
+    uid,
+    title,
+    start,
+    end,
+    allDay: false,
+    location: null,
+    notes: null,
+    calendar: "Work",
+    ...overrides,
+  };
+}
+
+describe("CalendarConflictScanner", () => {
+  it("reports overlapping events at highest priority", async () => {
+    const scanner = new CalendarConflictScanner(async () => [
+      event("one", "Planning", "2026-07-09T10:00:00.000Z", "2026-07-09T11:00:00.000Z"),
+      event("two", "Review", "2026-07-09T10:30:00.000Z", "2026-07-09T11:30:00.000Z", { calendar: "Personal" }),
+    ]);
+
+    await expect(scanner.scan(now)).resolves.toEqual([
+      expect.objectContaining({
+        key: expect.stringContaining("calendar-overlap"),
+        priority: 90,
+        summary: "Calendar conflict: “Planning” overlaps “Review”.",
+        evidence: expect.stringContaining("Work"),
+      }),
+    ]);
+  });
+
+  it("finds every overlap when a long event spans shorter ones", async () => {
+    const scanner = new CalendarConflictScanner(async () => [
+      event("long", "Workshop", "2026-07-09T10:00:00.000Z", "2026-07-09T12:00:00.000Z"),
+      event("short", "Standup", "2026-07-09T10:30:00.000Z", "2026-07-09T10:45:00.000Z"),
+      event("later", "Review", "2026-07-09T11:00:00.000Z", "2026-07-09T11:30:00.000Z"),
+    ]);
+
+    const candidates = await scanner.scan(now);
+    expect(candidates.filter((candidate) => candidate.key.startsWith("calendar-overlap"))).toHaveLength(2);
+  });
+
+  it("reports back-to-back and tight-gap events", async () => {
+    const scanner = new CalendarConflictScanner(async () => [
+      event("one", "Standup", "2026-07-09T10:00:00.000Z", "2026-07-09T10:30:00.000Z"),
+      event("two", "One-to-one", "2026-07-09T10:30:00.000Z", "2026-07-09T11:00:00.000Z"),
+      event("three", "Design", "2026-07-09T11:15:00.000Z", "2026-07-09T12:00:00.000Z"),
+    ]);
+
+    const candidates = await scanner.scan(now);
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]).toMatchObject({ priority: 70, summary: expect.stringContaining("Back-to-back") });
+    expect(candidates[1]).toMatchObject({ priority: 70, summary: expect.stringContaining("15 minutes") });
+  });
+
+  it("ignores all-day and already-ended events", async () => {
+    const scanner = new CalendarConflictScanner(async () => [
+      event("old", "Old", "2026-07-09T07:00:00.000Z", "2026-07-09T08:00:00.000Z"),
+      event("all-day", "Holiday", "2026-07-09T00:00:00.000Z", "2026-07-10T00:00:00.000Z", { allDay: true }),
+      event("next", "Next", "2026-07-09T10:00:00.000Z", "2026-07-09T11:00:00.000Z"),
+    ]);
+
+    await expect(scanner.scan(now)).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Completes #80 notice-loop calendar slice.

- Extracts typed EventKit calendar client from `macos_calendar` tool wrapper.
- Reads events across every configured macOS Calendar.
- Adds overlap and ≤15-minute gap notice scanner.
- Keeps non-macOS runtime journal-only.
- Adds focused client/scanner tests.

## User-facing behavior

With proactive notices enabled, Chris Assistant can surface upcoming overlapping or back-to-back calendar events. Calendar notices outrank journal-gap notices.

## Checks

- `npm run typecheck`
- `npm test` — 255/255 passed
- `npm run docs:build`
- Calendar/notice focused tests — 14/14 passed

## Manual acceptance

- [x] Calendar helper installed with `npm run setup:calendar-helper`.
- [ ] Grant macOS Calendar permission to `ChrisCalendar.app`, then run the live read-only scan. Current machine returned an EventKit launch/permission failure.

Closes #80.