### PR TITLE
feat: enforce test-first Symphony workflow

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -73,6 +73,12 @@ Working rules:
 
 - Follow the repository's `AGENTS.md` and any repo-local `.codex/skills`.
 - Work inside the current issue workspace only.
+- For behavior changes, use this test-first sequence before editing implementation code:
+  1. Write or update the smallest relevant test first.
+  2. Run that test and confirm it fails for the expected reason.
+  3. Implement the smallest change that makes the test pass.
+  4. Run the focused test again and confirm it passes.
+- Include the failing and passing test commands in the proof-of-work summary. Documentation-only and non-behavioral configuration changes may use a focused validation instead.
 - Prefer small, reviewable commits and keep the branch state clean.
 - If the issue already names the file to change, open that file directly and avoid broad repo exploration.
 - For small documentation-only edits, stay scoped to the named doc section, keep the patch minimal, and verify with a quick diff instead of wandering through unrelated files.

--- a/tests/symphony-workflow.test.ts
+++ b/tests/symphony-workflow.test.ts
@@ -50,4 +50,27 @@ Attempt: {{ attempt }}
     expect(rendered).toContain("Title: Build Symphony");
     expect(rendered).toContain("Attempt: 2");
   });
+
+  it("enforces a test-first implementation sequence in the repository workflow", async () => {
+    const workflowPath = path.resolve("WORKFLOW.md");
+    const workflow = loadWorkflow(workflowPath);
+    const rendered = await renderWorkflowPrompt(workflow, {
+      attempt: 1,
+      issue: {
+        identifier: "#84",
+        title: "Enforce test-first Symphony workflow",
+        description: "Stage 1 prompt contract",
+      },
+    });
+
+    const failingTest = rendered.indexOf("Write or update the smallest relevant test first");
+    const verifyFailure = rendered.indexOf("Run that test and confirm it fails for the expected reason");
+    const implementation = rendered.indexOf("Implement the smallest change that makes the test pass");
+    const verifyPass = rendered.indexOf("Run the focused test again and confirm it passes");
+
+    expect(failingTest).toBeGreaterThan(-1);
+    expect(verifyFailure).toBeGreaterThan(failingTest);
+    expect(implementation).toBeGreaterThan(verifyFailure);
+    expect(verifyPass).toBeGreaterThan(implementation);
+  });
 });


### PR DESCRIPTION
## Summary

Implements Stage 1 of #84.

- Require Symphony workers to write focused tests before implementation.
- Require expected failing-test proof before production changes.
- Require focused passing-test proof after minimal implementation.
- Add prompt-contract coverage for ordered workflow steps.

## Checks

- `npm run typecheck`
- `npm test` — 256/256 passed

Refs #84. Later self-review, CI retry, and review-comment stages remain separate.