### PR TITLE
feat: add event-sourced conversation log v1

### DIFF
--- a/docs/architecture/internals.md
+++ b/docs/architecture/internals.md
@@ -119,6 +119,8 @@ Telegram is now implemented under `src/channels/telegram/`:
 ### Persistent History
 Last 20 messages per chat in `~/.chris-assistant/conversations.json`. Loaded lazily, saved async via write queue. Fire-and-forget `addMessage()`, await `clearHistory()`. Metadata (`{ source?, channelName? }`) passed through to archive. `/clear` wipes history plus the active provider session. `/purge` also redacts today's archive.
 
+The v1 event store double-writes incoming messages, outgoing responses, and registered-tool results to daily `~/.chris-assistant/events/YYYY-MM-DD.jsonl` shards. Each event has an ID, correlation ID, timestamp, type, optional chat ID, and typed payload. `src/domain/events/projections/conversation-history.ts` can rebuild the `conversations.json`-compatible in-memory view or replay it up to a timestamp; existing conversation reads remain authoritative during this migration stage. Dashboard Conversations exposes raw daily event shards for inspection.
+
 ### Archive
 `conversation-archive.ts` — sync `appendFileSync` to `~/.chris-assistant/archive/YYYY-MM-DD.jsonl`. Each entry has optional `source` and `channelName` fields. Uploads to GitHub every 5 minutes (SHA-256 dedup). Exports: `readLocalArchive()`, `listLocalArchiveDates()`, `datestamp()`, `localArchivePath()`, `uploadArchives()`, `redactArchiveEntries()`.
 

--- a/src/agent/chat-service.ts
+++ b/src/agent/chat-service.ts
@@ -6,6 +6,7 @@ import { isOpenAiModel, isClaudeModel, isCodexAgentModel } from "../providers/mo
 import { createOpenAiProvider } from "../providers/openai.js";
 import { resetLoopDetection } from "../tools/index.js";
 import type { Provider, ImageAttachment } from "../providers/types.js";
+import { withEventContext } from "../domain/events/context.js";
 
 export interface ChatRequest {
   chatId: number;
@@ -44,15 +45,17 @@ export class ChatService {
   async sendMessage({ chatId, userMessage, onChunk, images, allowedTools, maxTurns }: ChatRequest): Promise<string> {
     resetLoopDetection();
 
-    if (images && images.length > 0) {
-      const imageModel = config.imageModel;
-      console.log("[provider] %d image(s) detected — routing to image model: %s", images.length, imageModel);
-      const response = await createOpenAiProvider(imageModel).chat(chatId, userMessage, onChunk, images, allowedTools);
-      this.clearSession(chatId);
-      return response;
-    }
+    return withEventContext(chatId, async () => {
+      if (images && images.length > 0) {
+        const imageModel = config.imageModel;
+        console.log("[provider] %d image(s) detected — routing to image model: %s", images.length, imageModel);
+        const response = await createOpenAiProvider(imageModel).chat(chatId, userMessage, onChunk, images, allowedTools);
+        this.clearSession(chatId);
+        return response;
+      }
 
-    return this.getProvider().chat(chatId, userMessage, onChunk, images, allowedTools, maxTurns);
+      return this.getProvider().chat(chatId, userMessage, onChunk, images, allowedTools, maxTurns);
+    });
   }
 
   clearSession(chatId: number): void {

--- a/src/channels/discord/handlers.ts
+++ b/src/channels/discord/handlers.ts
@@ -1,6 +1,7 @@
 import { ChannelType, Message, TextChannel } from "discord.js";
 import { config } from "../../config.js";
 import { addMessage } from "../../conversation.js";
+import { withEventContext } from "../../domain/events/context.js";
 import { stripMarkdown } from "../../markdown.js";
 import type { ImageAttachment } from "../../providers/types.js";
 import { chatService } from "../../agent/chat-service.js";
@@ -115,22 +116,22 @@ export function registerDiscordHandlers(): void {
       const channelName = message.channel.type === ChannelType.DM ? "dm" : (message.channel as TextChannel).name ?? "unknown";
       const meta = { source: "discord" as const, channelName };
 
-      void addMessage(chatId, "user", userMessage, meta);
-
-      const rawResponse = await chatService.sendMessage({
-        chatId,
-        userMessage,
-        images: imageAttachments.length > 0 ? imageAttachments : undefined,
-      });
-
       const thinkClose = "<" + "/think>";
       const thinkingClose = "<" + "/thinking>";
-      const response = rawResponse
-        .replace(new RegExp("<think>[\\s\\S]*?" + thinkClose, "g"), "")
-        .replace(new RegExp("<thinking>[\\s\\S]*?" + thinkingClose, "g"), "")
-        .trim();
-
-      void addMessage(chatId, "assistant", response, meta);
+      const response = await withEventContext(chatId, async () => {
+        void addMessage(chatId, "user", userMessage, meta);
+        const rawResponse = await chatService.sendMessage({
+          chatId,
+          userMessage,
+          images: imageAttachments.length > 0 ? imageAttachments : undefined,
+        });
+        const cleaned = rawResponse
+          .replace(new RegExp("<think>[\\s\\S]*?" + thinkClose, "g"), "")
+          .replace(new RegExp("<thinking>[\\s\\S]*?" + thinkingClose, "g"), "")
+          .trim();
+        void addMessage(chatId, "assistant", cleaned, meta);
+        return cleaned;
+      });
 
       const formatted = toDiscordMarkdown(response);
       const chunks = formatted.length <= 2000 ? [formatted] : splitDiscordMessage(formatted, 2000);

--- a/src/channels/telegram/callbacks.ts
+++ b/src/channels/telegram/callbacks.ts
@@ -3,6 +3,7 @@ import { InlineKeyboard } from "grammy";
 import { clearHistory } from "../../conversation.js";
 import { chatService } from "../../agent/chat-service.js";
 import { datestamp, redactArchiveEntries, uploadArchives } from "../../conversation-archive.js";
+import { eventDate, redactEventEntries } from "../../domain/events/log.js";
 import { encodeCallback, parseCallbackData } from "./callback-data.js";
 
 export function purgeConfirmKeyboard(): InlineKeyboard {
@@ -50,6 +51,7 @@ export function registerTelegramCallbackHandlers(bot: Bot<Context>): void {
         chatService.clearSession(chatId);
         const today = datestamp();
         const removed = redactArchiveEntries(chatId, today);
+        const removedEvents = await redactEventEntries(chatId, eventDate(Date.now()));
         if (removed > 0) {
           uploadArchives().catch((err: any) => {
             console.error("[telegram] Failed to upload redacted archive:", err.message);
@@ -58,9 +60,9 @@ export function registerTelegramCallbackHandlers(bot: Bot<Context>): void {
         await clearKeyboard(ctx);
         await ctx.answerCallbackQuery({ text: "Purged" }).catch(() => {});
         await ctx.reply(
-          removed > 0
-            ? `Conversation purged. ${removed} archive entries removed from today's log.`
-            : "Conversation cleared. No archive entries found for today.",
+          removed > 0 || removedEvents > 0
+            ? `Conversation purged. ${removed} archive entries and ${removedEvents} events removed from today's logs.`
+            : "Conversation cleared. No archive entries or events found for today.",
         );
         return;
       }

--- a/src/channels/telegram/handlers.ts
+++ b/src/channels/telegram/handlers.ts
@@ -6,6 +6,7 @@ import { chatService } from "../../agent/chat-service.js";
 import { downloadTelegramFile } from "./bot.js";
 import { config } from "../../config.js";
 import { BotMessageGuard } from "./bot-message-guard.js";
+import { withEventContext } from "../../domain/events/context.js";
 
 const RETRY_DELAY_MS = 2000;
 const MAX_TEXT_BYTES = 50_000;
@@ -75,13 +76,13 @@ async function handleAiResponse(
 
   try {
     const meta = { source: "telegram" as const };
-    void addMessage(chatId, "user", userMessage, meta);
-
-    const rawResponse = await chatWithRetry(chatId, userMessage, onChunk, image);
-
-    const response = stripThinking(rawResponse);
-
-    void addMessage(chatId, "assistant", response, meta);
+    const response = await withEventContext(chatId, async () => {
+      void addMessage(chatId, "user", userMessage, meta);
+      const rawResponse = await chatWithRetry(chatId, userMessage, onChunk, image);
+      const cleaned = stripThinking(rawResponse);
+      void addMessage(chatId, "assistant", cleaned, meta);
+      return cleaned;
+    });
 
     const chunks = response.length <= 4096 ? [response] : splitMessage(response, 4096);
     const firstChunk = chunks[0];

--- a/src/channels/web/handlers.ts
+++ b/src/channels/web/handlers.ts
@@ -2,6 +2,7 @@ import { addMessage } from "../../conversation.js";
 import { chatService } from "../../agent/chat-service.js";
 import { config } from "../../config.js";
 import type { ImageAttachment } from "../../providers/types.js";
+import { withEventContext } from "../../domain/events/context.js";
 
 export interface HandleWebMessageOptions {
   text: string;
@@ -20,14 +21,16 @@ export async function handleWebMessage(opts: HandleWebMessageOptions): Promise<v
   opts.signal.addEventListener("abort", onAbort, { once: true });
 
   try {
-    await addMessage(chatId, "user", opts.text, meta);
-    const reply = await chatService.sendMessage({
-      chatId,
-      userMessage: opts.text,
-      onChunk: opts.onChunk,
-      images: opts.images,
+    await withEventContext(chatId, async () => {
+      await addMessage(chatId, "user", opts.text, meta);
+      const reply = await chatService.sendMessage({
+        chatId,
+        userMessage: opts.text,
+        onChunk: opts.onChunk,
+        images: opts.images,
+      });
+      await addMessage(chatId, "assistant", reply, meta);
     });
-    await addMessage(chatId, "assistant", reply, meta);
   } finally {
     opts.signal.removeEventListener("abort", onAbort);
   }

--- a/src/dashboard/runtime.ts
+++ b/src/dashboard/runtime.ts
@@ -16,6 +16,7 @@ import { getBotProcess } from "../cli/pm2-helper.js";
 import { loadSkillIndex, loadSkill } from "../skills/loader.js";
 import { LIMITS } from "../infra/config/limits.js";
 import { REQUIRED_MEMORY_FILES } from "../domain/memory/constants.js";
+import { listEventDates, readEvents } from "../domain/events/log.js";
 
 const BOT_STARTED_AT = new Date().toISOString();
 const PM2_LOG_DIR = path.join(os.homedir(), ".pm2", "logs");
@@ -401,6 +402,10 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, getHtml:
     if (req.method === "GET" && pathname === "/api/conversation/stream") return handleConversationStream(req, res);
     if (req.method === "POST" && pathname === "/api/chat") return await handleChatPost(req, res);
     if (req.method === "GET" && pathname === "/api/archives") return handleArchives(res);
+    if (req.method === "GET" && pathname === "/api/events") return json(res, { dates: listEventDates() });
+
+    const eventDateMatch = pathname.match(/^\/api\/events\/(\d{4}-\d{2}-\d{2})$/);
+    if (req.method === "GET" && eventDateMatch) return json(res, { events: await readEvents(eventDateMatch[1]) });
 
     const archiveDateMatch = pathname.match(/^\/api\/archives\/(\d{4}-\d{2}-\d{2})$/);
     if (req.method === "GET" && archiveDateMatch) return handleArchiveDate(res, archiveDateMatch[1]);

--- a/src/dashboard/ui.html
+++ b/src/dashboard/ui.html
@@ -78,6 +78,11 @@ __DASHBOARD_DOCS_LINK__  </header>
       <div id="archive-dates" class="date-list"><div><div class="skeleton skeleton-pill"></div><div class="skeleton skeleton-pill"></div><div class="skeleton skeleton-pill"></div><div class="skeleton skeleton-pill"></div><div class="skeleton skeleton-pill"></div><div class="skeleton skeleton-pill"></div></div></div>
     </div>
     <div id="conversation-view"></div>
+    <div class="card">
+      <h3>Raw Event Stream</h3>
+      <div id="event-dates" class="date-list"><span class="loading">Loading events...</span></div>
+    </div>
+    <div id="event-view"></div>
   </div>
 
   <!-- Memory -->
@@ -626,6 +631,7 @@ async function deleteSchedule() {
 // --- Conversations ---
 let archiveDates = [];
 async function loadArchiveDates() {
+  loadEventDates();
   try {
     const data = await api("/api/archives");
     archiveDates = data.dates.reverse(); // newest first
@@ -644,6 +650,46 @@ async function loadArchiveDates() {
     }));
   } catch (e) {
     document.getElementById("archive-dates").innerHTML = '<span class="loading">Error: ' + esc(e.message) + '</span>';
+  }
+}
+
+async function loadEventDates() {
+  const el = document.getElementById("event-dates");
+  try {
+    const data = await api("/api/events");
+    const dates = data.dates.reverse();
+    if (dates.length === 0) {
+      el.innerHTML = '<span class="loading">No events recorded</span>';
+      return;
+    }
+    el.innerHTML = dates.map(d =>
+      '<button class="date-btn" data-event-date="' + d + '">' + d + '</button>'
+    ).join("");
+    el.querySelectorAll("[data-event-date]").forEach(b => b.addEventListener("click", () => {
+      el.querySelectorAll("[data-event-date]").forEach(x => x.classList.remove("active"));
+      b.classList.add("active");
+      loadEvents(b.dataset.eventDate);
+    }));
+  } catch (e) {
+    el.innerHTML = '<span class="loading">Error: ' + esc(e.message) + '</span>';
+  }
+}
+
+async function loadEvents(date) {
+  const view = document.getElementById("event-view");
+  view.innerHTML = '<div class="card"><span class="loading">Loading events...</span></div>';
+  try {
+    const data = await api("/api/events/" + date);
+    let html = '<div class="card"><h3>Events (' + data.events.length + ')</h3>';
+    for (const event of data.events) {
+      const time = new Date(event.ts).toLocaleTimeString();
+      html += '<div class="msg"><div class="meta">' + esc(event.type) + ' &middot; ' + time +
+        ' &middot; ' + esc(event.correlationId) + '</div><pre>' + esc(JSON.stringify(event.payload, null, 2)) + '</pre></div>';
+    }
+    html += '</div>';
+    view.innerHTML = html;
+  } catch (e) {
+    view.innerHTML = '<div class="card"><span class="loading">Error: ' + esc(e.message) + '</span></div>';
   }
 }
 

--- a/src/domain/conversations/history-service.ts
+++ b/src/domain/conversations/history-service.ts
@@ -4,7 +4,7 @@ import { ensureConversationStoreLoaded, saveConversationStore } from "./store.js
 import type { ConversationMessage, ConversationMeta } from "./types.js";
 import { tryDream } from "../memory/dream-service.js";
 import { LIMITS } from "../../infra/config/limits.js";
-import { appendEvent } from "../events/log.js";
+import { recordMessageEvent } from "../events/message-events.js";
 
 const MAX_HISTORY = LIMITS.historyWindow;
 // Token budget for history injected into new Claude sessions.
@@ -33,16 +33,7 @@ export async function addMessage(
   const now = Date.now();
   history.push({ role, content, timestamp: now });
   archiveMessage(chatId, role, content, now, meta);
-  try {
-    await appendEvent({
-      type: role === "user" ? "message.received" : "message.sent",
-      chatId,
-      ts: now,
-      payload: { role, content, meta },
-    });
-  } catch (error: any) {
-    console.error("[events] Failed to append message event:", error.message);
-  }
+  await recordMessageEvent({ chatId, role, content, meta, ts: now });
   conversationEvents.emit("message", { chatId, role, content, timestamp: now, meta });
 
   if (history.length > MAX_HISTORY) {

--- a/src/domain/conversations/history-service.ts
+++ b/src/domain/conversations/history-service.ts
@@ -4,6 +4,7 @@ import { ensureConversationStoreLoaded, saveConversationStore } from "./store.js
 import type { ConversationMessage, ConversationMeta } from "./types.js";
 import { tryDream } from "../memory/dream-service.js";
 import { LIMITS } from "../../infra/config/limits.js";
+import { appendEvent } from "../events/log.js";
 
 const MAX_HISTORY = LIMITS.historyWindow;
 // Token budget for history injected into new Claude sessions.
@@ -32,6 +33,16 @@ export async function addMessage(
   const now = Date.now();
   history.push({ role, content, timestamp: now });
   archiveMessage(chatId, role, content, now, meta);
+  try {
+    await appendEvent({
+      type: role === "user" ? "message.received" : "message.sent",
+      chatId,
+      ts: now,
+      payload: { role, content, meta },
+    });
+  } catch (error: any) {
+    console.error("[events] Failed to append message event:", error.message);
+  }
   conversationEvents.emit("message", { chatId, role, content, timestamp: now, meta });
 
   if (history.length > MAX_HISTORY) {

--- a/src/domain/events/context.ts
+++ b/src/domain/events/context.ts
@@ -1,0 +1,17 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+
+interface EventContext {
+  chatId: number;
+  correlationId: string;
+}
+
+const eventContext = new AsyncLocalStorage<EventContext>();
+
+export function withEventContext<T>(chatId: number, operation: () => Promise<T>): Promise<T> {
+  return eventContext.run({ chatId, correlationId: randomUUID() }, operation);
+}
+
+export function getEventContext(): EventContext | undefined {
+  return eventContext.getStore();
+}

--- a/src/domain/events/context.ts
+++ b/src/domain/events/context.ts
@@ -9,6 +9,8 @@ interface EventContext {
 const eventContext = new AsyncLocalStorage<EventContext>();
 
 export function withEventContext<T>(chatId: number, operation: () => Promise<T>): Promise<T> {
+  const existing = eventContext.getStore();
+  if (existing?.chatId === chatId) return operation();
   return eventContext.run({ chatId, correlationId: randomUUID() }, operation);
 }
 

--- a/src/domain/events/log.ts
+++ b/src/domain/events/log.ts
@@ -1,0 +1,59 @@
+import * as fs from "node:fs";
+import { randomUUID } from "node:crypto";
+import { appDataPath } from "../../infra/storage/paths.js";
+import type { AssistantEvent, AssistantEventType } from "./types.js";
+
+export const EVENTS_DIR = appDataPath("events");
+
+export function eventDate(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
+export function eventFilePath(date: string): string {
+  return `${EVENTS_DIR}/${date}.jsonl`;
+}
+
+export async function appendEvent<TPayload>(input: {
+  type: AssistantEventType;
+  chatId?: number;
+  payload: TPayload;
+  correlationId?: string;
+  ts?: number;
+}): Promise<AssistantEvent<TPayload>> {
+  const event: AssistantEvent<TPayload> = {
+    id: randomUUID(),
+    correlationId: input.correlationId ?? randomUUID(),
+    ts: input.ts ?? Date.now(),
+    type: input.type,
+    ...(input.chatId === undefined ? {} : { chatId: input.chatId }),
+    payload: input.payload,
+  };
+
+  await fs.promises.mkdir(EVENTS_DIR, { recursive: true });
+  await fs.promises.appendFile(eventFilePath(eventDate(event.ts)), `${JSON.stringify(event)}\n`, "utf-8");
+  return event;
+}
+
+export async function readEvents(date: string): Promise<AssistantEvent[]> {
+  try {
+    const raw = await fs.promises.readFile(eventFilePath(date), "utf-8");
+    return raw
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as AssistantEvent);
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+export function listEventDates(): string[] {
+  try {
+    return fs.readdirSync(EVENTS_DIR)
+      .filter((name) => /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(name))
+      .map((name) => name.slice(0, -6))
+      .sort();
+  } catch {
+    return [];
+  }
+}

--- a/src/domain/events/log.ts
+++ b/src/domain/events/log.ts
@@ -29,20 +29,59 @@ export async function appendEvent<TPayload>(input: {
     payload: input.payload,
   };
 
-  await fs.promises.mkdir(EVENTS_DIR, { recursive: true });
-  await fs.promises.appendFile(eventFilePath(eventDate(event.ts)), `${JSON.stringify(event)}\n`, "utf-8");
+  await fs.promises.mkdir(EVENTS_DIR, { recursive: true, mode: 0o700 });
+  await fs.promises.chmod(EVENTS_DIR, 0o700);
+  const handle = await fs.promises.open(eventFilePath(eventDate(event.ts)), "a", 0o600);
+  try {
+    await handle.chmod(0o600);
+    await handle.appendFile(`${JSON.stringify(event)}\n`, "utf-8");
+  } finally {
+    await handle.close();
+  }
   return event;
 }
 
 export async function readEvents(date: string): Promise<AssistantEvent[]> {
   try {
     const raw = await fs.promises.readFile(eventFilePath(date), "utf-8");
-    return raw
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as AssistantEvent);
+    const events: AssistantEvent[] = [];
+    for (const line of raw.split("\n").filter(Boolean)) {
+      try {
+        events.push(JSON.parse(line) as AssistantEvent);
+      } catch {
+        console.warn("[events] Ignoring corrupt record in %s", eventFilePath(date));
+      }
+    }
+    return events;
   } catch (error: any) {
     if (error?.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+/** Removes one chat's events from a shard while retaining other chats and corrupt records. */
+export async function redactEventEntries(chatId: number, date: string): Promise<number> {
+  const filePath = eventFilePath(date);
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf-8");
+    const kept: string[] = [];
+    let removed = 0;
+    for (const line of raw.split("\n").filter(Boolean)) {
+      try {
+        const event = JSON.parse(line) as AssistantEvent;
+        if (event.chatId === chatId) removed++;
+        else kept.push(line);
+      } catch {
+        kept.push(line);
+      }
+    }
+    if (removed > 0) {
+      await fs.promises.writeFile(filePath, kept.length > 0 ? `${kept.join("\n")}\n` : "", { mode: 0o600 });
+      await fs.promises.chmod(filePath, 0o600);
+    }
+    return removed;
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return 0;
     throw error;
   }
 }

--- a/src/domain/events/message-events.ts
+++ b/src/domain/events/message-events.ts
@@ -1,0 +1,24 @@
+import type { ConversationMeta } from "../conversations/types.js";
+import { getEventContext } from "./context.js";
+import { appendEvent } from "./log.js";
+
+export async function recordMessageEvent(input: {
+  chatId: number;
+  role: "user" | "assistant";
+  content: string;
+  meta?: ConversationMeta;
+  ts: number;
+}): Promise<void> {
+  const context = getEventContext();
+  try {
+    await appendEvent({
+      type: input.role === "user" ? "message.received" : "message.sent",
+      chatId: input.chatId,
+      correlationId: context?.chatId === input.chatId ? context.correlationId : undefined,
+      ts: input.ts,
+      payload: { role: input.role, content: input.content, meta: input.meta },
+    });
+  } catch (error: any) {
+    console.error("[events] Failed to append message event:", error.message);
+  }
+}

--- a/src/domain/events/projections/conversation-history.ts
+++ b/src/domain/events/projections/conversation-history.ts
@@ -1,0 +1,38 @@
+import type { ConversationMessage } from "../../conversations/types.js";
+import type { AssistantEvent, MessageEventPayload } from "../types.js";
+import { listEventDates, readEvents } from "../log.js";
+
+export interface ConversationProjectionOptions {
+  until?: number;
+  maxHistory?: number;
+}
+
+export function projectConversationHistory(
+  events: AssistantEvent[],
+  options: ConversationProjectionOptions = {},
+): Map<number, ConversationMessage[]> {
+  const projected = new Map<number, ConversationMessage[]>();
+  const maxHistory = options.maxHistory ?? Number.POSITIVE_INFINITY;
+
+  for (const event of events) {
+    if (options.until !== undefined && event.ts > options.until) continue;
+    if (event.chatId === undefined) continue;
+    if (event.type !== "message.received" && event.type !== "message.sent") continue;
+
+    const payload = event.payload as unknown as MessageEventPayload;
+    const history = projected.get(event.chatId) ?? [];
+    history.push({ role: payload.role, content: payload.content, timestamp: event.ts });
+    if (history.length > maxHistory) history.splice(0, history.length - maxHistory);
+    projected.set(event.chatId, history);
+  }
+
+  return projected;
+}
+
+/** Rebuilds the conversations.json-compatible in-memory view from all event shards. */
+export async function rebuildConversationHistory(
+  options: ConversationProjectionOptions = {},
+): Promise<Map<number, ConversationMessage[]>> {
+  const shards = await Promise.all(listEventDates().map((date) => readEvents(date)));
+  return projectConversationHistory(shards.flat().sort((a, b) => a.ts - b.ts), options);
+}

--- a/src/domain/events/tool-events.ts
+++ b/src/domain/events/tool-events.ts
@@ -9,12 +9,24 @@ export async function recordToolCompleted(input: {
   isError?: boolean;
 }): Promise<void> {
   const context = getEventContext();
+  let argsBytes = 0;
+  try {
+    argsBytes = Buffer.byteLength(JSON.stringify(input.args) ?? "", "utf-8");
+  } catch {
+    // Circular or otherwise unserializable arguments: record no content.
+  }
   try {
     await appendEvent({
       type: "tool.completed",
       chatId: context?.chatId,
       correlationId: context?.correlationId,
-      payload: { ...input, isError: input.isError ?? false },
+      payload: {
+        name: input.name,
+        provider: input.provider,
+        argsBytes,
+        resultBytes: Buffer.byteLength(input.result, "utf-8"),
+        isError: input.isError ?? false,
+      },
     });
   } catch (error: any) {
     console.error("[events] Failed to append tool event:", error.message);

--- a/src/domain/events/tool-events.ts
+++ b/src/domain/events/tool-events.ts
@@ -1,0 +1,22 @@
+import { getEventContext } from "./context.js";
+import { appendEvent } from "./log.js";
+
+export async function recordToolCompleted(input: {
+  name: string;
+  provider: string;
+  args: unknown;
+  result: string;
+  isError?: boolean;
+}): Promise<void> {
+  const context = getEventContext();
+  try {
+    await appendEvent({
+      type: "tool.completed",
+      chatId: context?.chatId,
+      correlationId: context?.correlationId,
+      payload: { ...input, isError: input.isError ?? false },
+    });
+  } catch (error: any) {
+    console.error("[events] Failed to append tool event:", error.message);
+  }
+}

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -20,7 +20,7 @@ export interface MessageEventPayload {
 export interface ToolCompletedEventPayload {
   name: string;
   provider: string;
-  args: unknown;
-  result: string;
+  argsBytes: number;
+  resultBytes: number;
   isError: boolean;
 }

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -1,0 +1,26 @@
+import type { ConversationMeta } from "../conversations/types.js";
+
+export type AssistantEventType = "message.received" | "message.sent" | "tool.completed";
+
+export interface AssistantEvent<TPayload = Record<string, unknown>> {
+  id: string;
+  correlationId: string;
+  ts: number;
+  type: AssistantEventType;
+  chatId?: number;
+  payload: TPayload;
+}
+
+export interface MessageEventPayload {
+  role: "user" | "assistant";
+  content: string;
+  meta?: ConversationMeta;
+}
+
+export interface ToolCompletedEventPayload {
+  name: string;
+  provider: string;
+  args: unknown;
+  result: string;
+  isError: boolean;
+}

--- a/src/domain/schedules/service.ts
+++ b/src/domain/schedules/service.ts
@@ -6,6 +6,7 @@ import { toMarkdownV2, stripThinking } from "../../markdown.js";
 import { matchesCron } from "./cron.js";
 import { readSchedules, readSchedulesWithRecovery, writeSchedules } from "./store.js";
 import type { NewSchedule, Schedule, ScheduleUpdates } from "./types.js";
+import { withEventContext } from "../events/context.js";
 
 async function sendTelegramMessage(text: string, title?: string): Promise<void> {
   const url = `https://api.telegram.org/bot${config.telegram.botToken}/sendMessage`;
@@ -59,39 +60,42 @@ async function executeTask(task: Schedule): Promise<void> {
   const meta = { source: "scheduled" as const };
 
   try {
-    const response = await chatService.sendMessage({
-      chatId,
-      userMessage: task.prompt,
-      allowedTools: task.allowedTools,
-    });
+    await withEventContext(chatId, async () => {
+      const response = await chatService.sendMessage({
+        chatId,
+        userMessage: task.prompt,
+        allowedTools: task.allowedTools,
+      });
+      const trimmed = stripThinking(response);
 
-    const trimmed = stripThinking(response);
-
-    // Detect error fallback strings that indicate the AI call failed.
-    // claude.ts now throws on non-abort errors, but guard here too in case
-    // another provider returns an error string instead of throwing.
-    if (trimmed && (trimmed.startsWith("API Error:") || trimmed.startsWith("I hit an issue:"))) {
-      throw new Error(trimmed.slice(0, 200));
-    }
-
-    if (!trimmed || trimmed.startsWith("NOUPDATE:")) {
-      console.log("[scheduler] No update for task: %s — staying quiet", task.name);
-    } else {
-      // Store the prompt and response in conversation history so the user
-      // can ask follow-up questions and the bot retains context
-      void addMessage(chatId, "user", `[Scheduled: ${task.name}] ${task.prompt}`, meta);
-      void addMessage(chatId, "assistant", trimmed, meta);
-
-      if (task.discordChannel) {
-        await sendToDiscordChannel(task.discordChannel, trimmed);
-      } else {
-        await sendTelegramMessage(toMarkdownV2(trimmed), task.name);
+      // Detect error fallback strings that indicate the AI call failed.
+      // claude.ts now throws on non-abort errors, but guard here too in case
+      // another provider returns an error string instead of throwing.
+      if (trimmed && (trimmed.startsWith("API Error:") || trimmed.startsWith("I hit an issue:"))) {
+        throw new Error(trimmed.slice(0, 200));
       }
-    }
 
-    task.lastRun = Date.now();
-    writeSchedules(readSchedules());
-    console.log("[scheduler] Task completed: %s", task.name);
+      if (!trimmed || trimmed.startsWith("NOUPDATE:")) {
+        console.log("[scheduler] No update for task: %s — staying quiet", task.name);
+      } else {
+        // Store the prompt and response in conversation history so the user
+        // can ask follow-up questions and the bot retains context
+        await withEventContext(chatId, async () => {
+          void addMessage(chatId, "user", `[Scheduled: ${task.name}] ${task.prompt}`, meta);
+          void addMessage(chatId, "assistant", trimmed, meta);
+        });
+
+        if (task.discordChannel) {
+          await sendToDiscordChannel(task.discordChannel, trimmed);
+        } else {
+          await sendTelegramMessage(toMarkdownV2(trimmed), task.name);
+        }
+      }
+
+      task.lastRun = Date.now();
+      writeSchedules(readSchedules());
+      console.log("[scheduler] Task completed: %s", task.name);
+    });
   } catch (err: any) {
     console.error("[scheduler] Task failed: %s — %s", task.name, err.message);
     await sendTelegramMessage(`[${task.name}] Failed: ${err.message}`).catch(() => {});

--- a/src/tools/claude-mcp-adapter.ts
+++ b/src/tools/claude-mcp-adapter.ts
@@ -2,6 +2,7 @@ import { tool as createMcpTool } from "@anthropic-ai/claude-agent-sdk";
 import { checkToolLoop } from "./loop-guard.js";
 import { filterTools } from "./filtering.js";
 import { getRegisteredTools } from "./store.js";
+import { recordToolCompleted } from "../domain/events/tool-events.js";
 
 const NATIVE_CLAUDE_TOOLS = new Set([
   "read_file",
@@ -30,6 +31,7 @@ function toMcpTool(tool: ReturnType<typeof getRegisteredTools>[number]) {
 
     const result = await tool.execute(args);
     const isError = /^(Unknown|Failed|Error|rejected|denied)/i.test(result) || result.includes("rejected:");
+    await recordToolCompleted({ name: tool.name, provider: "claude", args, result, isError });
     return {
       content: [{ type: "text" as const, text: result }],
       ...(isError && { isError: true }),

--- a/src/tools/openai-adapter.ts
+++ b/src/tools/openai-adapter.ts
@@ -2,6 +2,7 @@ import type { ChatCompletionTool } from "openai/resources/chat/completions";
 import { checkToolLoop } from "./loop-guard.js";
 import { filterTools } from "./filtering.js";
 import { getRegisteredTool } from "./store.js";
+import { recordToolCompleted } from "../domain/events/tool-events.js";
 
 export function getOpenAiToolDefinitions(includeCoding = true, allowedTools?: string[]): ChatCompletionTool[] {
   return filterTools(includeCoding, allowedTools).map((t) => ({
@@ -24,9 +25,13 @@ export async function dispatchToolCall(name: string, argsJson: string, logPrefix
 
     const args = JSON.parse(argsJson);
     console.log("[%s] Tool call: %s(%s)", logPrefix, name, JSON.stringify(args).slice(0, 100));
-    return await tool.execute(args);
+    const result = await tool.execute(args);
+    await recordToolCompleted({ name, provider: logPrefix, args, result });
+    return result;
   } catch (err: any) {
     console.error("[%s] Bad tool call arguments for %s:", logPrefix, name, argsJson);
-    return `Failed to parse tool arguments: ${err.message}`;
+    const result = `Failed to parse tool arguments: ${err.message}`;
+    await recordToolCompleted({ name, provider: logPrefix, args: argsJson, result, isError: true });
+    return result;
   }
 }

--- a/tests/event-log.test.ts
+++ b/tests/event-log.test.ts
@@ -11,14 +11,27 @@ vi.mock("../src/infra/storage/paths.js", () => ({
   appDataPath: (...parts: string[]) => path.join(root, ...parts),
 }));
 
-import { appendEvent, eventDate, readEvents } from "../src/domain/events/log.js";
+import {
+  appendEvent,
+  EVENTS_DIR,
+  eventDate,
+  eventFilePath,
+  readEvents,
+  redactEventEntries,
+} from "../src/domain/events/log.js";
+import { withEventContext } from "../src/domain/events/context.js";
+import { recordMessageEvent } from "../src/domain/events/message-events.js";
+import { recordToolCompleted } from "../src/domain/events/tool-events.js";
 import {
   projectConversationHistory,
   rebuildConversationHistory,
 } from "../src/domain/events/projections/conversation-history.js";
 
 beforeEach(() => fs.rmSync(root, { recursive: true, force: true }));
-afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(root, { recursive: true, force: true });
+});
 
 describe("event log", () => {
   it("appends JSONL events and replays conversation history after restart", async () => {
@@ -61,5 +74,61 @@ describe("event log", () => {
 
   it("returns no events when a day has no shard", async () => {
     await expect(readEvents("2026-01-01")).resolves.toEqual([]);
+  });
+
+  it("correlates a turn and stores only safe tool metadata", async () => {
+    const ts = Date.UTC(2026, 6, 12, 11, 0, 0);
+    vi.spyOn(Date, "now").mockReturnValue(ts);
+
+    await withEventContext(42, async () => {
+      await recordMessageEvent({ chatId: 42, role: "user", content: "hello", ts });
+      await recordToolCompleted({
+        name: "ssh",
+        provider: "claude",
+        args: { command: "echo secret-token" },
+        result: "secret-output",
+      });
+      await recordMessageEvent({ chatId: 42, role: "assistant", content: "done", ts: ts + 1 });
+    });
+
+    const events = await readEvents(eventDate(ts));
+    expect([...new Set(events.map((event) => event.correlationId))]).toHaveLength(1);
+    const tool = events.find((event) => event.type === "tool.completed")!;
+    expect(tool.payload).toMatchObject({ name: "ssh", provider: "claude", isError: false });
+    expect(JSON.stringify(tool.payload)).not.toContain("secret");
+  });
+
+  it("creates private event storage permissions", async () => {
+    const ts = Date.UTC(2026, 6, 12, 12, 0, 0);
+    await appendEvent({ type: "message.received", chatId: 1, ts, payload: { role: "user", content: "hi" } });
+
+    expect(fs.statSync(EVENTS_DIR).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(eventFilePath(eventDate(ts))).mode & 0o777).toBe(0o600);
+  });
+
+  it("ignores corrupt records without losing later valid events", async () => {
+    const ts = Date.UTC(2026, 6, 12, 13, 0, 0);
+    const date = eventDate(ts);
+    await appendEvent({ type: "message.received", chatId: 1, ts, payload: { role: "user", content: "before" } });
+    fs.appendFileSync(eventFilePath(date), "{truncated\n");
+    await appendEvent({ type: "message.sent", chatId: 1, ts: ts + 1, payload: { role: "assistant", content: "after" } });
+
+    await expect(readEvents(date)).resolves.toHaveLength(2);
+  });
+
+  it("redacts one chat while preserving other chats and corrupt records", async () => {
+    const ts = Date.UTC(2026, 6, 12, 14, 0, 0);
+    const date = eventDate(ts);
+    await appendEvent({ type: "message.received", chatId: 42, ts, payload: { role: "user", content: "remove" } });
+    await appendEvent({ type: "tool.completed", chatId: 42, ts: ts + 1, payload: { name: "x", provider: "test", argsBytes: 1, resultBytes: 1, isError: false } });
+    await appendEvent({ type: "message.received", chatId: 7, ts: ts + 2, payload: { role: "user", content: "keep" } });
+    fs.appendFileSync(eventFilePath(date), "{corrupt\n");
+
+    await expect(redactEventEntries(42, date)).resolves.toBe(2);
+    const raw = fs.readFileSync(eventFilePath(date), "utf-8");
+    expect(raw).toContain("{corrupt");
+    const events = await readEvents(date);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.chatId).toBe(7);
   });
 });

--- a/tests/event-log.test.ts
+++ b/tests/event-log.test.ts
@@ -1,0 +1,65 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { root } = vi.hoisted(() => ({
+  root: "/tmp/chris-assistant-event-log-test",
+}));
+
+vi.mock("../src/infra/storage/paths.js", () => ({
+  APP_DATA_DIR: root,
+  appDataPath: (...parts: string[]) => path.join(root, ...parts),
+}));
+
+import { appendEvent, eventDate, readEvents } from "../src/domain/events/log.js";
+import {
+  projectConversationHistory,
+  rebuildConversationHistory,
+} from "../src/domain/events/projections/conversation-history.js";
+
+beforeEach(() => fs.rmSync(root, { recursive: true, force: true }));
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe("event log", () => {
+  it("appends JSONL events and replays conversation history after restart", async () => {
+    const ts = Date.UTC(2026, 6, 12, 10, 0, 0);
+    await appendEvent({
+      type: "message.received",
+      chatId: 42,
+      correlationId: "turn-1",
+      ts,
+      payload: { role: "user", content: "hello" },
+    });
+    await appendEvent({
+      type: "message.sent",
+      chatId: 42,
+      correlationId: "turn-1",
+      ts: ts + 1,
+      payload: { role: "assistant", content: "hi" },
+    });
+
+    const persisted = await readEvents(eventDate(ts));
+    expect(persisted).toHaveLength(2);
+    const replayed = await rebuildConversationHistory();
+
+    expect(replayed.get(42)).toEqual([
+      { role: "user", content: "hello", timestamp: ts },
+      { role: "assistant", content: "hi", timestamp: ts + 1 },
+    ]);
+  });
+
+  it("supports time-travel projection up to a timestamp", async () => {
+    const events = [
+      { id: "1", correlationId: "a", ts: 100, type: "message.received" as const, chatId: 7, payload: { role: "user", content: "before" } },
+      { id: "2", correlationId: "a", ts: 200, type: "message.sent" as const, chatId: 7, payload: { role: "assistant", content: "after" } },
+    ];
+
+    expect(projectConversationHistory(events, { until: 150 }).get(7)).toEqual([
+      { role: "user", content: "before", timestamp: 100 },
+    ]);
+  });
+
+  it("returns no events when a day has no shard", async () => {
+    await expect(readEvents("2026-01-01")).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements issue #87 v1 double-write foundation.

- Append incoming messages, outgoing responses, and registered-tool metadata to daily event JSONL shards.
- Correlate each channel turn across user, tool, and assistant events.
- Keep tool arguments/results out of event storage; record only safe size/status metadata.
- Enforce private storage permissions: event directory `0700`, shards `0600`.
- Tolerate corrupt/truncated JSONL records during replay.
- Extend Telegram `/purge` to remove matching chat events from today's shard.
- Rebuild conversation-history projection from all shards with timestamp-bounded time travel.
- Expose authenticated raw event dates and payloads in dashboard Conversations view.
- Keep existing `conversations.json` reads authoritative during migration.

## Checks

- `npm run typecheck`
- `npm test` — 281/281 passed
- Focused overlap tests — 15/15 passed
- GitHub Actions `check` passed

Refs #87. Projection read cutover remains v2.