### PR TITLE
feat: capture counterfactual decisions

### DIFF
--- a/docs/tools/memory.md
+++ b/docs/tools/memory.md
@@ -20,6 +20,7 @@ chris-assistant-memory/
 │   ├── SUMMARY.md            # Weekly-consolidated curated summary (read-only)
 │   ├── DASHBOARD.md          # Operator-facing status and notes
 │   ├── learnings.md          # Self-improvement notes
+├── decisions/                # Structured counterfactual decision records
 ├── HEARTBEAT.md              # Bot status snapshot (updated every 3h)
 ├── archive/                  # Daily JSONL message logs
 ├── journal/                  # Bot's daily journal notes
@@ -71,6 +72,48 @@ The tool targets specific memory file categories: `about-chris`, `preferences`, 
 | `people` | `USER.md` | People you mention — names, context |
 | `decisions` | `memory/learnings.md` | Important decisions and reasoning |
 | `learnings` | `memory/learnings.md` | Things the bot learned about how to help you better |
+
+## Counterfactual Decision Records
+
+Important choices should use `update_memory` with `category: decisions`, `action: add`, and a structured `decision` payload. This preserves rejected options and review triggers instead of recording only final choice. Each record is committed to `decisions/YYYY-MM-DD-<choice>.md`; a readable summary is also appended to `memory/learnings.md` and indexed locally for recall.
+
+Schema:
+
+```yaml
+type: decision
+date: YYYY-MM-DD
+chose: selected option
+alternatives:
+  - name: rejected option
+    rejected_because: evidence-based reason
+reasoning_trace:
+  - evidence or constraint that influenced choice
+revisit_conditions:
+  - condition: event that would justify reviewing choice
+    review_on: YYYY-MM-DD # optional
+    status: pending # pending, met, or dismissed; optional
+```
+
+Representative example (documentation fixture, not user memory):
+
+```yaml
+type: decision
+date: "2026-07-01"
+chose: Keep SQLite for v1
+alternatives:
+  - name: Move to Postgres
+    rejected_because: Migration cost exceeds current scale benefit
+reasoning_trace:
+  - Single-node workload remains within SQLite limits
+revisit_conditions:
+  - condition: Concurrent writes become a bottleneck
+    status: pending
+  - condition: Quarterly architecture review
+    review_on: "2026-10-01"
+    status: pending
+```
+
+`decisions_due_for_revisit` scans structured local decision files. It returns records with `status: met` or `review_on` at/before requested `as_of` date. `dismissed` conditions never make record due.
 
 ## Memory Guard
 

--- a/src/domain/memory/constants.ts
+++ b/src/domain/memory/constants.ts
@@ -25,6 +25,7 @@ export const MEMORY_DIRECTORIES = [
   "journal/",
   "archive/",
   "conversations/summaries/",
+  "decisions/",
   "skills/",
 ] as const;
 

--- a/src/domain/memory/decision-service.ts
+++ b/src/domain/memory/decision-service.ts
@@ -1,0 +1,136 @@
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { LOCAL_MEMORY_DIR } from "./recall.js";
+
+export interface DecisionAlternative {
+  name: string;
+  rejected_because: string;
+}
+
+export interface DecisionRevisitCondition {
+  condition: string;
+  review_on?: string;
+  status?: "pending" | "met" | "dismissed";
+}
+
+export interface DecisionRecord {
+  type: "decision";
+  date: string;
+  chose: string;
+  alternatives: DecisionAlternative[];
+  reasoning_trace: string[];
+  revisit_conditions: DecisionRevisitCondition[];
+}
+
+export type DecisionInput = Omit<DecisionRecord, "type">;
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function validateDecision(input: DecisionInput): string | null {
+  if (!ISO_DATE.test(input.date)) return "decision.date must use YYYY-MM-DD";
+  if (!input.chose.trim()) return "decision.chose must not be empty";
+  if (input.alternatives.length === 0) return "decision.alternatives must include at least one rejected option";
+  if (input.alternatives.some((item) => !item.name.trim() || !item.rejected_because.trim())) {
+    return "each decision alternative needs name and rejected_because";
+  }
+  if (input.reasoning_trace.length === 0 || input.reasoning_trace.some((reason) => !reason.trim())) {
+    return "decision.reasoning_trace must include at least one reason";
+  }
+  if (input.revisit_conditions.some((item) => !item.condition.trim())) {
+    return "each revisit condition needs a condition";
+  }
+  if (input.revisit_conditions.some((item) => item.review_on && !ISO_DATE.test(item.review_on))) {
+    return "revisit condition review_on must use YYYY-MM-DD";
+  }
+  return null;
+}
+
+export function asDecisionRecord(input: DecisionInput): DecisionRecord {
+  return { type: "decision", ...input };
+}
+
+export function formatDecisionFrontmatter(input: DecisionInput): string {
+  return stringifyYaml(asDecisionRecord(input)).trimEnd();
+}
+
+function decisionSlug(chose: string): string {
+  return chose
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .slice(0, 60) || "decision";
+}
+
+export function decisionRecordPath(input: DecisionInput): string {
+  return `decisions/${input.date}-${decisionSlug(input.chose)}.md`;
+}
+
+export function formatDecisionDocument(input: DecisionInput): string {
+  return `---\n${formatDecisionFrontmatter(input)}\n---\n\n${formatDecisionMemory(input)}\n`;
+}
+
+export function formatDecisionMemory(input: DecisionInput): string {
+  const alternatives = input.alternatives
+    .map((item) => `- **${item.name}** — rejected because ${item.rejected_because}`)
+    .join("\n");
+  const reasoning = input.reasoning_trace.map((item) => `- ${item}`).join("\n");
+  const revisit = input.revisit_conditions.length > 0
+    ? input.revisit_conditions.map((item) => {
+      const review = item.review_on ? `; review on ${item.review_on}` : "";
+      return `- ${item.condition}${review}; status: ${item.status ?? "pending"}`;
+    }).join("\n")
+    : "- No revisit conditions recorded.";
+
+  return `## Decision: ${input.chose}\n\n- **Date:** ${input.date}\n- **Chose:** ${input.chose}\n\n### Alternatives\n${alternatives}\n\n### Reasoning trace\n${reasoning}\n\n### Revisit conditions\n${revisit}`;
+}
+
+function parseDecision(content: string): DecisionRecord | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+  try {
+    const parsed = parseYaml(match[1]) as DecisionRecord;
+    if (parsed?.type !== "decision") return null;
+    const error = validateDecision(parsed);
+    return error ? null : parsed;
+  } catch {
+    return null;
+  }
+}
+
+function isDue(condition: DecisionRevisitCondition, asOf: string): boolean {
+  if (condition.status === "dismissed") return false;
+  return condition.status === "met" || (!!condition.review_on && condition.review_on <= asOf);
+}
+
+export async function decisionsDueForRevisit(
+  asOf = new Date().toISOString().slice(0, 10),
+  memoryDir = LOCAL_MEMORY_DIR,
+): Promise<DecisionRecord[]> {
+  const entries = await readdir(memoryDir, { recursive: true }).catch(() => [] as string[]);
+  const files = entries.filter((entry) => entry.endsWith(".md"));
+  const parsed = await Promise.all(files.map(async (entry) => {
+    const content = await readFile(join(memoryDir, entry), "utf-8").catch(() => "");
+    return parseDecision(content);
+  }));
+
+  return parsed
+    .filter((record): record is DecisionRecord => record !== null)
+    .filter((record) => record.revisit_conditions.some((condition) => isDue(condition, asOf)))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export function formatDecisionsDue(records: DecisionRecord[], asOf: string): string {
+  if (records.length === 0) return `No decisions due for revisit as of ${asOf}.`;
+  return [
+    `Decisions due for revisit as of ${asOf}:`,
+    ...records.map((record) => {
+      const due = record.revisit_conditions
+        .filter((condition) => isDue(condition, asOf))
+        .map((condition) => condition.condition)
+        .join("; ");
+      return `- ${record.date}: ${record.chose} — ${due}`;
+    }),
+  ].join("\n");
+}

--- a/src/domain/memory/decision-service.ts
+++ b/src/domain/memory/decision-service.ts
@@ -27,8 +27,17 @@ export type DecisionInput = Omit<DecisionRecord, "type">;
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
+export function isIsoCalendarDate(value: string): boolean {
+  if (!ISO_DATE.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  if (month < 1 || month > 12 || day < 1) return false;
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1];
+}
+
 export function validateDecision(input: DecisionInput): string | null {
-  if (!ISO_DATE.test(input.date)) return "decision.date must use YYYY-MM-DD";
+  if (!isIsoCalendarDate(input.date)) return "decision.date must be a valid YYYY-MM-DD date";
   if (!input.chose.trim()) return "decision.chose must not be empty";
   if (input.alternatives.length === 0) return "decision.alternatives must include at least one rejected option";
   if (input.alternatives.some((item) => !item.name.trim() || !item.rejected_because.trim())) {
@@ -40,8 +49,8 @@ export function validateDecision(input: DecisionInput): string | null {
   if (input.revisit_conditions.some((item) => !item.condition.trim())) {
     return "each revisit condition needs a condition";
   }
-  if (input.revisit_conditions.some((item) => item.review_on && !ISO_DATE.test(item.review_on))) {
-    return "revisit condition review_on must use YYYY-MM-DD";
+  if (input.revisit_conditions.some((item) => item.review_on && !isIsoCalendarDate(item.review_on))) {
+    return "revisit condition review_on must be a valid YYYY-MM-DD date";
   }
   return null;
 }

--- a/src/domain/memory/memory-scan.ts
+++ b/src/domain/memory/memory-scan.ts
@@ -11,7 +11,7 @@ import { readdir, stat, readFile } from "fs/promises";
 import { basename, join } from "path";
 import { parse as parseYaml } from "yaml";
 
-export type MemoryType = "user" | "feedback" | "project" | "reference";
+export type MemoryType = "user" | "feedback" | "project" | "reference" | "decision";
 
 export interface MemoryHeader {
   filename: string;
@@ -24,7 +24,7 @@ export interface MemoryHeader {
 const MAX_MEMORY_FILES = 200;
 const FRONTMATTER_BYTES = 2048; // read first 2KB — enough for any frontmatter
 
-const VALID_TYPES = new Set<MemoryType>(["user", "feedback", "project", "reference"]);
+const VALID_TYPES = new Set<MemoryType>(["user", "feedback", "project", "reference", "decision"]);
 
 function parseMemoryType(raw: unknown): MemoryType | undefined {
   if (typeof raw !== "string") return undefined;

--- a/src/domain/memory/update-service.ts
+++ b/src/domain/memory/update-service.ts
@@ -274,19 +274,21 @@ export async function executeMemoryTool(args: {
   const entry = `<!-- Updated: ${timestamp} -->\n${content}`;
 
   try {
-    if (action === "replace") {
-      await writeMemoryFile(filePath, entry, `memory: replace ${category}`);
-      lastReplaceTime.set(category, Date.now());
-    } else {
-      await appendToMemoryFile(filePath, entry, `memory: add to ${category}`);
-    }
-
+    // Write structured record first. Its stable path makes retries idempotent:
+    // a retry replaces the same record before attempting the append again.
     if (args.decision) {
       await writeMemoryFile(
         decisionRecordPath(args.decision),
         formatDecisionDocument(args.decision),
         `memory: record decision ${args.decision.chose.slice(0, 60)}`,
       );
+    }
+
+    if (action === "replace") {
+      await writeMemoryFile(filePath, entry, `memory: replace ${category}`);
+      lastReplaceTime.set(category, Date.now());
+    } else {
+      await appendToMemoryFile(filePath, entry, `memory: add to ${category}`);
     }
 
     // Dual-write: also persist as a local topic file for recall. GitHub remains

--- a/src/domain/memory/update-service.ts
+++ b/src/domain/memory/update-service.ts
@@ -5,6 +5,14 @@ import { MEMORY_CATEGORY_FILES } from "./constants.js";
 import { LOCAL_MEMORY_DIR } from "./recall.js";
 import { updateVoyageEntry } from "./voyage-index.js";
 import type { MemoryHeader } from "./memory-scan.js";
+import {
+  formatDecisionFrontmatter,
+  formatDecisionDocument,
+  formatDecisionMemory,
+  decisionRecordPath,
+  validateDecision,
+  type DecisionInput,
+} from "./decision-service.js";
 
 const CONTENT_MAX_CHARS = 2000;
 const REPLACE_THROTTLE_MS = 5 * 60 * 1000;
@@ -198,20 +206,22 @@ function autoDescription(content: string, category: string): string {
 async function writeLocalMemoryFile(
   category: string,
   content: string,
+  decision?: DecisionInput,
 ): Promise<MemoryHeader | null> {
   try {
     await mkdir(LOCAL_MEMORY_DIR, { recursive: true });
-    const type = CATEGORY_TO_TYPE[category] || "reference";
+    const type = decision ? "decision" : (CATEGORY_TO_TYPE[category] || "reference");
     const timestamp = new Date().toISOString().split("T")[0];
     const slug = slugify(content);
     const filename = `${category}_${timestamp}_${slug}.md`;
     const filePath = path.join(LOCAL_MEMORY_DIR, filename);
     const description = autoDescription(content, category);
 
+    const frontmatter = decision
+      ? `${formatDecisionFrontmatter(decision)}\ndescription: ${JSON.stringify(description)}`
+      : `name: ${category} — ${slug.replace(/-/g, " ")}\ndescription: ${description}\ntype: ${type}`;
     const fileContent = `---
-name: ${category} — ${slug.replace(/-/g, " ")}
-description: ${description}
-type: ${type}
+${frontmatter}
 ---
 
 ${content}
@@ -231,13 +241,32 @@ ${content}
   }
 }
 
-export async function executeMemoryTool(args: { category: string; action: "add" | "replace"; content: string }): Promise<string> {
-  const validation = validateMemoryContent(args);
+export async function executeMemoryTool(args: {
+  category: string;
+  action: "add" | "replace";
+  content?: string;
+  decision?: DecisionInput;
+}): Promise<string> {
+  if (args.decision && args.category !== "decisions") {
+    return "Memory update rejected: structured decision requires category decisions";
+  }
+  if (args.decision && args.action !== "add") {
+    return "Memory update rejected: structured decisions only support add";
+  }
+  if (!args.decision && !args.content?.trim()) {
+    return "Memory update rejected: content is required";
+  }
+  if (args.decision) {
+    const decisionError = validateDecision(args.decision);
+    if (decisionError) return `Memory update rejected: ${decisionError}`;
+  }
+  const content = args.decision ? formatDecisionMemory(args.decision) : args.content!;
+  const validation = validateMemoryContent({ ...args, content });
   if (!validation.valid) {
     return `Memory update rejected: ${validation.reason}`;
   }
 
-  const { category, action, content } = args;
+  const { category, action } = args;
   const filePath = MEMORY_CATEGORY_FILES[category];
   if (!filePath) return `Unknown category: ${category}`;
 
@@ -252,9 +281,17 @@ export async function executeMemoryTool(args: { category: string; action: "add" 
       await appendToMemoryFile(filePath, entry, `memory: add to ${category}`);
     }
 
+    if (args.decision) {
+      await writeMemoryFile(
+        decisionRecordPath(args.decision),
+        formatDecisionDocument(args.decision),
+        `memory: record decision ${args.decision.chose.slice(0, 60)}`,
+      );
+    }
+
     // Dual-write: also persist as a local topic file for recall. GitHub remains
     // the source of truth; local/Voyage failures are logged but non-fatal.
-    const localHeader = await writeLocalMemoryFile(category, content);
+    const localHeader = await writeLocalMemoryFile(category, content, args.decision);
     if (localHeader) {
       await updateVoyageEntry(localHeader);
     }

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -104,6 +104,7 @@ You are **Chris Assistant**: Chris's personal assistant with memory, purpose, co
 
 - Preserve the feeling of a personal assistant first. Use coding-agent abilities when useful, but do not let tool/runtime branding replace your identity.
 - Treat memory, journal notes, and recent summaries as part of your continuity with Chris.
+- For meaningful decisions, capture counterfactual context: chosen option, rejected alternatives and why, reasoning trace, and revisit conditions. Use \`decisions_due_for_revisit\` when planning or when conditions may have changed.
 - Be explicit about the active model or provider if asked, while still identifying as Chris Assistant.`;
 }
 
@@ -279,7 +280,7 @@ Triggers for each category:
 - **preferences**: Chris expresses a like, dislike, opinion, or style preference (food, tech, communication, workflow)
 - **projects**: Chris mentions starting, finishing, or making progress on a project — or shifts what he's focused on
 - **people**: Chris mentions someone by name — save who they are and their relationship/context
-- **decisions**: Chris makes or announces a decision (career, technical, life) — save what was decided and why
+- **decisions**: Chris makes or announces a decision (career, technical, life) — use structured decision capture when alternatives are known. Record chosen option, rejected alternatives and why, reasoning trace, and concrete revisit conditions. Use decisions_due_for_revisit when planning or when conditions may have changed.
 - **learnings**: You discover something about how Chris prefers to interact, what kind of answers work best, or a mistake you should avoid repeating
 
 **Journal** — You have a daily journal via journal_entry. After substantive conversations — decisions made, important topics discussed, tasks completed, things learned about Chris, or mood observations — write a brief note. These notes persist and help you maintain continuity across conversations. Don't journal every message — focus on what's worth remembering tomorrow.

--- a/src/tools/decisions.ts
+++ b/src/tools/decisions.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
-import { decisionsDueForRevisit, formatDecisionsDue } from "../domain/memory/decision-service.js";
+import {
+  decisionsDueForRevisit,
+  formatDecisionsDue,
+  isIsoCalendarDate,
+} from "../domain/memory/decision-service.js";
 import { registerTool } from "./registry.js";
+
+export async function executeDecisionsDueForRevisit({ as_of }: { as_of?: string }): Promise<string> {
+  const asOf = as_of ?? new Date().toISOString().slice(0, 10);
+  if (!isIsoCalendarDate(asOf)) return "Invalid as_of date; expected a valid YYYY-MM-DD date";
+  return formatDecisionsDue(await decisionsDueForRevisit(asOf), asOf);
+}
 
 registerTool({
   name: "decisions_due_for_revisit",
@@ -16,9 +26,5 @@ registerTool({
       as_of: { type: "string", description: "Optional cutoff date in YYYY-MM-DD format" },
     },
   },
-  execute: async ({ as_of }: { as_of?: string }) => {
-    const asOf = as_of ?? new Date().toISOString().slice(0, 10);
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(asOf)) return "Invalid as_of date; expected YYYY-MM-DD";
-    return formatDecisionsDue(await decisionsDueForRevisit(asOf), asOf);
-  },
+  execute: executeDecisionsDueForRevisit,
 });

--- a/src/tools/decisions.ts
+++ b/src/tools/decisions.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { decisionsDueForRevisit, formatDecisionsDue } from "../domain/memory/decision-service.js";
+import { registerTool } from "./registry.js";
+
+registerTool({
+  name: "decisions_due_for_revisit",
+  category: "always",
+  description: "List structured decisions whose review date has arrived or whose revisit condition is marked met.",
+  zodSchema: {
+    as_of: z.string().optional().describe("Cutoff date in YYYY-MM-DD format; defaults to today"),
+  },
+  jsonSchemaParameters: {
+    type: "object",
+    required: [],
+    properties: {
+      as_of: { type: "string", description: "Optional cutoff date in YYYY-MM-DD format" },
+    },
+  },
+  execute: async ({ as_of }: { as_of?: string }) => {
+    const asOf = as_of ?? new Date().toISOString().slice(0, 10);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(asOf)) return "Invalid as_of date; expected YYYY-MM-DD";
+    return formatDecisionsDue(await decisionsDueForRevisit(asOf), asOf);
+  },
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,6 +2,7 @@
 // The order here controls registration order, which determines the order of
 // tool definitions sent to providers.
 import "./memory.js";
+import "./decisions.js";
 import "./web-search.js";
 import "./fetch-url.js";
 import "./browse-url.js";

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -2,6 +2,21 @@ import { z } from "zod";
 import { registerTool } from "./registry.js";
 import { executeMemoryTool } from "../memory/tools.js";
 
+const decisionSchema = z.object({
+  date: z.string().describe("Decision date in YYYY-MM-DD format"),
+  chose: z.string().describe("Option selected"),
+  alternatives: z.array(z.object({
+    name: z.string(),
+    rejected_because: z.string(),
+  })).describe("Options considered but not chosen, with rejection reasons"),
+  reasoning_trace: z.array(z.string()).describe("Evidence and reasoning behind choice"),
+  revisit_conditions: z.array(z.object({
+    condition: z.string().describe("What would justify reviewing decision"),
+    review_on: z.string().optional().describe("Optional review date in YYYY-MM-DD format"),
+    status: z.enum(["pending", "met", "dismissed"]).optional(),
+  })).describe("Triggers or dates that should reopen decision"),
+});
+
 registerTool({
   name: "update_memory",
   description: `Update persistent memory about Chris. Use proactively — don't wait to be asked. Categories:
@@ -9,7 +24,7 @@ registerTool({
 - preferences: likes, dislikes, opinions, style, tools, workflow habits
 - projects: active projects and status changes
 - people: names, relationships, context
-- decisions: significant choices and their reasoning
+- decisions: significant choices, rejected alternatives, reasoning trace, and revisit conditions. Prefer structured decision payload.
 - learnings: patterns in how to better serve him (interaction style, what to avoid)`,
   zodSchema: {
     category: z.enum([
@@ -23,13 +38,16 @@ registerTool({
     action: z.enum(["add", "replace"]).describe(
       "add: append new info. replace: rewrite the entire file (use sparingly, only to correct/consolidate).",
     ),
-    content: z.string().describe(
+    content: z.string().optional().describe(
       "The memory content. Be specific, concise, factual. Use bullet points for multiple items.",
+    ),
+    decision: decisionSchema.optional().describe(
+      "Structured counterfactual record. Only valid with category=decisions and action=add.",
     ),
   },
   jsonSchemaParameters: {
     type: "object",
-    required: ["category", "action", "content"],
+    required: ["category", "action"],
     properties: {
       category: {
         type: "string",
@@ -52,6 +70,36 @@ registerTool({
         type: "string",
         description:
           "The memory content. Be specific, concise, factual. Use bullet points for multiple items.",
+      },
+      decision: {
+        type: "object",
+        description: "Structured counterfactual record. Only valid for decisions/add.",
+        required: ["date", "chose", "alternatives", "reasoning_trace", "revisit_conditions"],
+        properties: {
+          date: { type: "string", description: "YYYY-MM-DD" },
+          chose: { type: "string" },
+          alternatives: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["name", "rejected_because"],
+              properties: { name: { type: "string" }, rejected_because: { type: "string" } },
+            },
+          },
+          reasoning_trace: { type: "array", items: { type: "string" } },
+          revisit_conditions: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["condition"],
+              properties: {
+                condition: { type: "string" },
+                review_on: { type: "string", description: "Optional YYYY-MM-DD review date" },
+                status: { type: "string", enum: ["pending", "met", "dismissed"] },
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/tests/decision-memory.test.ts
+++ b/tests/decision-memory.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  decisionsDueForRevisit,
+  decisionRecordPath,
+  formatDecisionDocument,
+  formatDecisionFrontmatter,
+  formatDecisionsDue,
+  validateDecision,
+  type DecisionInput,
+} from "../src/domain/memory/decision-service.js";
+import { scanMemoryFiles } from "../src/domain/memory/memory-scan.js";
+
+let tempDir: string | null = null;
+
+const decision: DecisionInput = {
+  date: "2026-07-01",
+  chose: "Keep SQLite for v1",
+  alternatives: [
+    { name: "Move to Postgres", rejected_because: "migration cost exceeds current scale benefit" },
+  ],
+  reasoning_trace: ["Single-node workload remains within SQLite limits"],
+  revisit_conditions: [
+    { condition: "Concurrent writes become a bottleneck", status: "pending" },
+    { condition: "Quarterly architecture review", review_on: "2026-07-10", status: "pending" },
+  ],
+};
+
+afterEach(async () => {
+  if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  tempDir = null;
+});
+
+async function writeDecision(input: DecisionInput, name = "decision.md"): Promise<string> {
+  tempDir ??= await mkdtemp(join(tmpdir(), "chris-decisions-"));
+  const path = join(tempDir, name);
+  await writeFile(path, `---\n${formatDecisionFrontmatter(input)}\n---\n\nDecision details\n`);
+  return path;
+}
+
+describe("counterfactual decision memory", () => {
+  it("validates required counterfactual fields", () => {
+    expect(validateDecision(decision)).toBeNull();
+    expect(validateDecision({ ...decision, alternatives: [] })).toContain("at least one rejected option");
+    expect(validateDecision({ ...decision, date: "01/07/2026" })).toContain("YYYY-MM-DD");
+  });
+
+  it("serializes stable YAML schema", async () => {
+    const path = await writeDecision(decision);
+    const saved = await readFile(path, "utf-8");
+
+    expect(saved).toContain("type: decision");
+    expect(saved).toContain("date: 2026-07-01");
+    expect(saved).toContain("chose: Keep SQLite for v1");
+    expect(saved).toContain("rejected_because:");
+    expect(saved).toContain("reasoning_trace:");
+    expect(saved).toContain("revisit_conditions:");
+
+    const headers = await scanMemoryFiles(tempDir!);
+    expect(headers).toEqual([
+      expect.objectContaining({ filename: "decision.md", type: "decision" }),
+    ]);
+  });
+
+  it("creates a stable durable decision path and document", () => {
+    expect(decisionRecordPath(decision)).toBe("decisions/2026-07-01-keep-sqlite-for-v1.md");
+    expect(formatDecisionDocument(decision)).toMatch(/^---\ntype: decision/);
+    expect(formatDecisionDocument(decision)).toContain("## Decision: Keep SQLite for v1");
+  });
+
+  it("returns decisions whose review date is due", async () => {
+    await writeDecision(decision, "due.md");
+    await writeDecision({
+      ...decision,
+      chose: "Keep current queue",
+      revisit_conditions: [{ condition: "Annual review", review_on: "2027-01-01" }],
+    }, "future.md");
+
+    const due = await decisionsDueForRevisit("2026-07-12", tempDir!);
+
+    expect(due.map((record) => record.chose)).toEqual(["Keep SQLite for v1"]);
+    expect(formatDecisionsDue(due, "2026-07-12")).toContain("Quarterly architecture review");
+  });
+
+  it("returns met conditions immediately and excludes dismissed conditions", async () => {
+    await writeDecision({
+      ...decision,
+      revisit_conditions: [{ condition: "Latency exceeds SLO", status: "met" }],
+    }, "met.md");
+    await writeDecision({
+      ...decision,
+      chose: "Dismissed choice",
+      revisit_conditions: [{ condition: "Old trigger", review_on: "2020-01-01", status: "dismissed" }],
+    }, "dismissed.md");
+
+    const due = await decisionsDueForRevisit("2026-07-12", tempDir!);
+    expect(due.map((record) => record.chose)).toEqual(["Keep SQLite for v1"]);
+  });
+});

--- a/tests/decision-memory.test.ts
+++ b/tests/decision-memory.test.ts
@@ -8,10 +8,12 @@ import {
   formatDecisionDocument,
   formatDecisionFrontmatter,
   formatDecisionsDue,
+  isIsoCalendarDate,
   validateDecision,
   type DecisionInput,
 } from "../src/domain/memory/decision-service.js";
 import { scanMemoryFiles } from "../src/domain/memory/memory-scan.js";
+import { executeDecisionsDueForRevisit } from "../src/tools/decisions.js";
 
 let tempDir: string | null = null;
 
@@ -45,6 +47,13 @@ describe("counterfactual decision memory", () => {
     expect(validateDecision(decision)).toBeNull();
     expect(validateDecision({ ...decision, alternatives: [] })).toContain("at least one rejected option");
     expect(validateDecision({ ...decision, date: "01/07/2026" })).toContain("YYYY-MM-DD");
+    expect(validateDecision({ ...decision, date: "2026-02-29" })).toContain("valid YYYY-MM-DD");
+    expect(validateDecision({
+      ...decision,
+      revisit_conditions: [{ condition: "Impossible review", review_on: "2026-13-01" }],
+    })).toContain("valid YYYY-MM-DD");
+    expect(isIsoCalendarDate("2024-02-29")).toBe(true);
+    expect(isIsoCalendarDate("2026-02-29")).toBe(false);
   });
 
   it("serializes stable YAML schema", async () => {
@@ -82,6 +91,11 @@ describe("counterfactual decision memory", () => {
 
     expect(due.map((record) => record.chose)).toEqual(["Keep SQLite for v1"]);
     expect(formatDecisionsDue(due, "2026-07-12")).toContain("Quarterly architecture review");
+  });
+
+  it("rejects impossible as_of dates", async () => {
+    expect(await executeDecisionsDueForRevisit({ as_of: "2026-02-29" }))
+      .toBe("Invalid as_of date; expected a valid YYYY-MM-DD date");
   });
 
   it("returns met conditions immediately and excludes dismissed conditions", async () => {

--- a/tests/memory-guard.test.ts
+++ b/tests/memory-guard.test.ts
@@ -114,6 +114,35 @@ describe("global token bucket", () => {
     expect(updateVoyageEntry).toHaveBeenCalledWith(expect.objectContaining({ type: "decision" }));
   });
 
+  it("retries structured decisions without duplicating the summary append", async () => {
+    const structuredArgs = {
+      category: "decisions" as const,
+      action: "add" as const,
+      decision: {
+        date: "2026-07-12",
+        chose: "Use stable writes before append",
+        alternatives: [{ name: "Append first", rejected_because: "retries can duplicate summaries" }],
+        reasoning_trace: ["Stable-path writes are idempotent"],
+        revisit_conditions: [],
+      },
+    };
+    vi.mocked(appendToMemoryFile)
+      .mockRejectedValueOnce(new Error("summary write failed"))
+      .mockResolvedValueOnce(undefined);
+
+    expect(await executeMemoryTool(structuredArgs)).toBe("Failed to update memory: summary write failed");
+    expect(await executeMemoryTool(structuredArgs)).toBe("Memory updated (decisions/add)");
+
+    expect(writeMemoryFile).toHaveBeenCalledTimes(2);
+    expect(writeMemoryFile).toHaveBeenNthCalledWith(
+      1,
+      "decisions/2026-07-12-use-stable-writes-before-append.md",
+      expect.stringContaining("type: decision"),
+      "memory: record decision Use stable writes before append",
+    );
+    expect(appendToMemoryFile).toHaveBeenCalledTimes(2);
+  });
+
   it("updates the Voyage index after writing a local recall file", async () => {
     const result = await callUpdate("preferences", "Chris prefers concise updates");
     expect(result).toBe("Memory updated (preferences/add)");

--- a/tests/memory-guard.test.ts
+++ b/tests/memory-guard.test.ts
@@ -43,6 +43,8 @@ import {
   setGlobalBucketClock,
 } from "../src/domain/memory/update-service.js";
 import { updateVoyageEntry } from "../src/domain/memory/voyage-index.js";
+import { appendToMemoryFile } from "../src/domain/memory/repository.js";
+import { writeMemoryFile } from "../src/domain/memory/repository.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -76,6 +78,8 @@ beforeEach(() => {
   setGlobalBucketClock(() => Date.now());
   resetGlobalBucket();
   vi.mocked(updateVoyageEntry).mockClear();
+  vi.mocked(appendToMemoryFile).mockClear();
+  vi.mocked(writeMemoryFile).mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -83,6 +87,33 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("global token bucket", () => {
+  it("captures structured decisions with counterfactual context", async () => {
+    const result = await executeMemoryTool({
+      category: "decisions",
+      action: "add",
+      decision: {
+        date: "2026-07-12",
+        chose: "Ship smallest safe slice",
+        alternatives: [{ name: "Big-bang rewrite", rejected_because: "risk and review cost" }],
+        reasoning_trace: ["Incremental delivery preserves rollback"],
+        revisit_conditions: [{ condition: "Incremental path blocks required migration", status: "pending" }],
+      },
+    });
+
+    expect(result).toBe("Memory updated (decisions/add)");
+    expect(appendToMemoryFile).toHaveBeenCalledWith(
+      "memory/learnings.md",
+      expect.stringContaining("### Alternatives"),
+      "memory: add to decisions",
+    );
+    expect(writeMemoryFile).toHaveBeenCalledWith(
+      "decisions/2026-07-12-ship-smallest-safe-slice.md",
+      expect.stringContaining("type: decision"),
+      "memory: record decision Ship smallest safe slice",
+    );
+    expect(updateVoyageEntry).toHaveBeenCalledWith(expect.objectContaining({ type: "decision" }));
+  });
+
   it("updates the Voyage index after writing a local recall file", async () => {
     const result = await callUpdate("preferences", "Chris prefers concise updates");
     expect(result).toBe("Memory updated (preferences/add)");

--- a/tests/memory-schema.test.ts
+++ b/tests/memory-schema.test.ts
@@ -53,8 +53,8 @@ describe("canonical memory schema", () => {
       "journal/",
       "archive/",
       "conversations/summaries/",
+      "decisions/",
       "skills/",
     ]);
   });
 });
-

--- a/tests/prompt-contract.test.ts
+++ b/tests/prompt-contract.test.ts
@@ -127,6 +127,15 @@ describe("assistant runtime prompt contract", () => {
     expect(prompt).toContain("Tools Available");
   });
 
+  it("guides counterfactual decision capture and revisit queries", async () => {
+    for (const prompt of await assembledPrompts()) {
+      expect(prompt).toContain("rejected alternatives and why");
+      expect(prompt).toContain("reasoning trace");
+      expect(prompt).toContain("revisit conditions");
+      expect(prompt).toContain("decisions_due_for_revisit");
+    }
+  });
+
   it("assembles identity, curated memory, recent summaries, recalled memories, and current time for every provider", async () => {
     for (const prompt of await assembledPrompts("what should you remember about my trading agent?")) {
       expect(prompt).toContain("Chris Assistant is warm, direct, and continuous.");


### PR DESCRIPTION
## Summary

Implements issue #89 v1.

- Add structured counterfactual decision payloads to `update_memory`.
- Persist durable YAML-frontmatter decision records under `decisions/*.md`.
- Retain local decision recall/index entries.
- Add `decisions_due_for_revisit` for due dates and met conditions.
- Add cross-provider prompt guidance and memory schema documentation.
- Cover validation, serialization, querying, memory guards, and prompt contract.

## Checks

- `npm run typecheck`
- Focused tests — 33/33 passed
- `npm test` — 262/262 passed

Refs #89.

## Follow-up

Remote decision-record hydration into a missing local index remains separate; current query reads persistent local decision files created by normal dual-write flow.