### PR TITLE
chore: guard force-push workflow

### DIFF
--- a/.claude/hooks/guard-force-push.sh
+++ b/.claude/hooks/guard-force-push.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# PreToolUse guard: block bare `git push --force` / `-f`.
+# This repo has recurring stacked-PR + squash-merge rebase conflicts
+# (see memory: git-pr-workflow.md) where a bare force-push can clobber
+# a remote branch that moved since the local rebase. Require
+# --force-with-lease (or --force-if-includes) instead.
+set -euo pipefail
+
+input="$(cat)"
+tool_name="$(echo "$input" | jq -r '.tool_name // empty')"
+
+if [ "$tool_name" != "Bash" ]; then
+  exit 0
+fi
+
+command="$(echo "$input" | jq -r '.tool_input.command // empty')"
+
+# Only care about commands that actually run `git push`.
+if ! echo "$command" | grep -qE 'git[[:space:]]+push'; then
+  exit 0
+fi
+
+# Already using a safe force variant — allow.
+if echo "$command" | grep -qE 'force-with-lease|force-if-includes'; then
+  exit 0
+fi
+
+# Bare --force or short -f flag present — block.
+if echo "$command" | grep -qE -- '--force([[:space:]=]|$)|(^|[[:space:]])-f([[:space:]]|$)'; then
+  echo "Blocked: bare 'git push --force' (or -f) detected. This project has recurring stacked-PR force-push conflicts — use 'git push --force-with-lease' instead, which fails safely if the remote has commits you don't have locally. See memory: git-pr-workflow.md." >&2
+  exit 2
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 .claude/skills/wiki-ingest/
+.claude/settings.local.json
 .memsearch/
 .codex/
 docs/.vitepress/cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ Critical ones inline, full list in `docs/development/gotchas.md`:
 - **SSH + pm2**: `~/.ssh/config` `Host` line must include IP for pm2 to resolve correct user
 - **Codex API**: Requires `stream: true`, `store: false`, `chatgpt-account-id` header. Only GPT-5.x models
 - **Memory cache**: 5-min TTL, invalidated after each conversation
+- **Stacked PRs + squash merge**: if PR-B branches from PR-A and PR-A gets squash-merged, GitHub deletes PR-A's branch and falsely marks PR-B "merged" even though its commits never landed on `main` (squash merge isn't a fast-forward). Before squash-merging a base PR, retarget dependent PRs to `main` first (`gh pr edit <n> --base main`); otherwise recreate via cherry-pick. Prefer independent PRs off `main` over stacking; when rebasing is unavoidable after a sequential merge, use `git push --force-with-lease` (never bare `--force`)
+- **Docs deploy**: `docs.mjoln1r.com` is VitePress output rsynced to the `tuckinandtalk` VM. Deploy with `npm run docs:deploy`; `.git/hooks/post-merge` auto-deploys on `docs/` changes after `git pull` (hook source tracked at `scripts/post-merge-hook` for reinstall)
 
 ## Environment
 


### PR DESCRIPTION
## Summary

- Block bare `git push --force` and `git push -f` in Claude Bash hooks.
- Allow `--force-with-lease` and `--force-if-includes`.
- Document stacked-PR squash-merge and docs-deploy gotchas.
- Ignore machine-local Claude settings.

## Checks

- `bash -n .claude/hooks/guard-force-push.sh`
- Safe force-with-lease input accepted.
- Bare force input rejected with exit 2.
- `git diff --check`